### PR TITLE
add custom auth dialog (get rid of account manager)

### DIFF
--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -2,13 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.nextcloud.android.sso">
 
-    <uses-permission android:name="com.nextcloud.android.sso" />
     <uses-permission android:name="android.permission.INTERNET"/>
-
     <uses-permission android:name="android.permission.GET_ACCOUNTS" />
-    <uses-permission
-        android:name="android.permission.USE_CREDENTIALS"
-        android:maxSdkVersion="22" />
 
     <application android:label="@string/app_name" />
 </manifest>

--- a/src/main/java/com/nextcloud/android/sso/Constants.java
+++ b/src/main/java/com/nextcloud/android/sso/Constants.java
@@ -3,9 +3,14 @@ package com.nextcloud.android.sso;
 public class Constants {
 
     // Authenticator related constants
-    public final static String SSO_USERNAME = "username";
-    public final static String SSO_TOKEN = "token";
-    public final static String SSO_SERVER_URL = "server_url";
+    public static final String SSO_USERNAME = "username";
+    public static final String SSO_TOKEN = "token";
+    public static final String SSO_SERVER_URL = "server_url";
+    public static final String SSO_SHARED_PREFERENCE = "single-sign-on";
+    public static final String NEXTCLOUD_SSO_EXCEPTION = "NextcloudSsoException";
+    public static final String NEXTCLOUD_SSO = "NextcloudSSO";
+    public static final String NEXTCLOUD_FILES_ACCOUNT = "NextcloudFilesAccount";
+
 
     // Custom Exceptions
     public static final String EXCEPTION_INVALID_TOKEN = "CE_1";
@@ -13,4 +18,5 @@ public class Constants {
     public static final String EXCEPTION_UNSUPPORTED_METHOD = "CE_3";
     public static final String EXCEPTION_INVALID_REQUEST_URL = "CE_4";
     public static final String EXCEPTION_HTTP_REQUEST_FAILED = "CE_5";
+    public static final String EXCEPTION_ACCOUNT_ACCESS_DECLINED = "CE_6";
 }

--- a/src/main/java/com/nextcloud/android/sso/api/NextcloudAPI.java
+++ b/src/main/java/com/nextcloud/android/sso/api/NextcloudAPI.java
@@ -11,16 +11,10 @@ import android.os.RemoteException;
 import android.util.Log;
 
 import com.google.gson.Gson;
-import com.nextcloud.android.sso.Constants;
 import com.nextcloud.android.sso.aidl.IInputStreamService;
 import com.nextcloud.android.sso.aidl.IThreadListener;
 import com.nextcloud.android.sso.aidl.NextcloudRequest;
 import com.nextcloud.android.sso.aidl.ParcelFileDescriptorUtil;
-import com.nextcloud.android.sso.exceptions.NextcloudFilesAppAccountNotFoundException;
-import com.nextcloud.android.sso.exceptions.NextcloudHttpRequestFailedException;
-import com.nextcloud.android.sso.exceptions.NextcloudInvalidRequestUrlException;
-import com.nextcloud.android.sso.exceptions.NextcloudUnsupportedMethodException;
-import com.nextcloud.android.sso.exceptions.TokenMismatchException;
 import com.nextcloud.android.sso.helper.ExponentialBackoff;
 import com.nextcloud.android.sso.model.SingleSignOnAccount;
 
@@ -39,6 +33,8 @@ import java.lang.reflect.Type;
 
 import io.reactivex.Observable;
 import io.reactivex.annotations.NonNull;
+
+import static com.nextcloud.android.sso.exceptions.SSOException.ParseAndThrowNextcloudCustomException;
 
 /**
  *  Nextcloud SingleSignOn
@@ -235,26 +231,13 @@ public class NextcloudAPI {
         // Handle Remote Exceptions
         if(exception != null) {
             if(exception.getMessage() != null) {
-                switch (exception.getMessage()) {
-                    case Constants.EXCEPTION_INVALID_TOKEN:
-                        throw new TokenMismatchException();
-                    case Constants.EXCEPTION_ACCOUNT_NOT_FOUND:
-                        throw new NextcloudFilesAppAccountNotFoundException();
-                    case Constants.EXCEPTION_UNSUPPORTED_METHOD:
-                        throw new NextcloudUnsupportedMethodException();
-                    case Constants.EXCEPTION_INVALID_REQUEST_URL:
-                        throw new NextcloudInvalidRequestUrlException(exception.getCause().getMessage());
-                    case Constants.EXCEPTION_HTTP_REQUEST_FAILED:
-                        int statusCode = Integer.parseInt(exception.getCause().getMessage());
-                        throw new NextcloudHttpRequestFailedException(statusCode);
-                    default:
-                        throw exception;
-                }
+                ParseAndThrowNextcloudCustomException(exception);
             }
             throw exception;
         }
         return os;
     }
+
 
     /**
      * DO NOT CALL THIS METHOD DIRECTLY - use "performNetworkRequest(...)" instead

--- a/src/main/java/com/nextcloud/android/sso/exceptions/NextcloudFilesAppAccountPermissionNotGrantedException.java
+++ b/src/main/java/com/nextcloud/android/sso/exceptions/NextcloudFilesAppAccountPermissionNotGrantedException.java
@@ -1,0 +1,36 @@
+package com.nextcloud.android.sso.exceptions;
+
+import android.content.Context;
+
+import com.nextcloud.android.sso.R;
+import com.nextcloud.android.sso.model.ExceptionMessage;
+
+/**
+ *  Nextcloud SingleSignOn
+ *
+ *  @author David Luhmer
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+public class NextcloudFilesAppAccountPermissionNotGrantedException extends SSOException {
+
+    @Override
+    public void loadExceptionMessage(Context context) {
+        this.em = new ExceptionMessage(
+                context.getString(R.string.nextcloud_files_app_account_permission_not_granted_title),
+                context.getString(R.string.nextcloud_files_app_account_permission_not_granted_message)
+        );
+    }
+}

--- a/src/main/java/com/nextcloud/android/sso/exceptions/SSOException.java
+++ b/src/main/java/com/nextcloud/android/sso/exceptions/SSOException.java
@@ -4,9 +4,8 @@ import android.app.Application;
 import android.content.Context;
 import android.util.Log;
 
+import com.nextcloud.android.sso.Constants;
 import com.nextcloud.android.sso.model.ExceptionMessage;
-
-import java.lang.reflect.InvocationTargetException;
 
 /**
  *  Nextcloud SingleSignOn
@@ -83,5 +82,26 @@ public class SSOException extends Exception {
             Log.e(TAG, e.getMessage());
         }
         return null;
+    }
+
+
+    public static void ParseAndThrowNextcloudCustomException(Exception exception) throws Exception {
+        switch (exception.getMessage()) {
+            case Constants.EXCEPTION_INVALID_TOKEN:
+                throw new TokenMismatchException();
+            case Constants.EXCEPTION_ACCOUNT_NOT_FOUND:
+                throw new NextcloudFilesAppAccountNotFoundException();
+            case Constants.EXCEPTION_UNSUPPORTED_METHOD:
+                throw new NextcloudUnsupportedMethodException();
+            case Constants.EXCEPTION_INVALID_REQUEST_URL:
+                throw new NextcloudInvalidRequestUrlException(exception.getCause().getMessage());
+            case Constants.EXCEPTION_HTTP_REQUEST_FAILED:
+                int statusCode = Integer.parseInt(exception.getCause().getMessage());
+                throw new NextcloudHttpRequestFailedException(statusCode);
+            case Constants.EXCEPTION_ACCOUNT_ACCESS_DECLINED:
+                throw new NextcloudFilesAppAccountPermissionNotGrantedException();
+            default:
+                throw exception;
+        }
     }
 }

--- a/src/main/java/com/nextcloud/android/sso/helper/SingleAccountHelper.java
+++ b/src/main/java/com/nextcloud/android/sso/helper/SingleAccountHelper.java
@@ -1,20 +1,13 @@
 package com.nextcloud.android.sso.helper;
 
-import android.accounts.Account;
-import android.accounts.AuthenticatorException;
-import android.accounts.OperationCanceledException;
 import android.content.Context;
 import android.content.SharedPreferences;
 
-import java.io.IOException;
-
 import com.nextcloud.android.sso.AccountImporter;
 import com.nextcloud.android.sso.exceptions.CurrentAccountNotFoundException;
-import com.nextcloud.android.sso.exceptions.NextcloudFilesAppNotSupportedException;
+import com.nextcloud.android.sso.exceptions.NextcloudFilesAppAccountNotFoundException;
 import com.nextcloud.android.sso.exceptions.NoCurrentAccountSelectedException;
 import com.nextcloud.android.sso.model.SingleSignOnAccount;
-
-import static android.content.Context.MODE_PRIVATE;
 
 /**
  *  Nextcloud SingleSignOn
@@ -39,30 +32,24 @@ public final class SingleAccountHelper {
 
     private SingleAccountHelper() { }
 
-    private static final String TAG = SingleAccountHelper.class.getCanonicalName();
-    private static final String PREF_FILE_NAME = "PrefNextcloudAccount";
-    private static final String PREF_ACCOUNT_STRING = "PREF_ACCOUNT_STRING";
+    private static final String PREF_SINGLE_ACCOUNT_STRING = "PREF_ACCOUNT_STRING";
 
-    public static Account getCurrentAccount(Context context) throws NoCurrentAccountSelectedException, CurrentAccountNotFoundException {
-        SharedPreferences preferences = context.getSharedPreferences(PREF_FILE_NAME, MODE_PRIVATE);
-        String accountName = preferences.getString(PREF_ACCOUNT_STRING, null);
+    private static String getCurrentAccountName(Context context) throws NoCurrentAccountSelectedException {
+        SharedPreferences mPrefs = AccountImporter.GetSharedPreferences(context);
+        String accountName = mPrefs.getString(PREF_SINGLE_ACCOUNT_STRING, null);
         if(accountName == null) {
             throw new NoCurrentAccountSelectedException();
         }
-        Account account = AccountImporter.GetAccountForName(context, accountName);
-        if(account == null) {
-            throw new CurrentAccountNotFoundException();
-        }
-        return account;
+        return accountName;
     }
 
-    public static SingleSignOnAccount getCurrentSingleAccount(Context context) throws AuthenticatorException, OperationCanceledException, IOException, NoCurrentAccountSelectedException, CurrentAccountNotFoundException, NextcloudFilesAppNotSupportedException {
-        return AccountImporter.GetAuthToken(context, getCurrentAccount(context));
+    public static SingleSignOnAccount getCurrentSingleSignOnAccount(Context context) throws NextcloudFilesAppAccountNotFoundException, NoCurrentAccountSelectedException, CurrentAccountNotFoundException {
+        return AccountImporter.GetSingleSignOnAccount(context, getCurrentAccountName(context));
     }
 
-    public static void setCurrentAccount(Context context, Account account) {
-        SharedPreferences preferences = context.getSharedPreferences(PREF_FILE_NAME, MODE_PRIVATE);
-        preferences.edit().putString(PREF_ACCOUNT_STRING, account.name).commit();
+    public static void setCurrentAccount(Context context, String accountName) {
+        SharedPreferences mPrefs = AccountImporter.GetSharedPreferences(context);
+        mPrefs.edit().putString(PREF_SINGLE_ACCOUNT_STRING, accountName).commit();
     }
 
 }

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -16,6 +16,9 @@
     <string name="nextcloud_files_app_account_not_found_title">Error</string>
     <string name="nextcloud_files_app_account_not_found_message">Account not found in nextcloud files app</string>
 
+    <string name="nextcloud_files_app_account_permission_not_granted_title">Error</string>
+    <string name="nextcloud_files_app_account_permission_not_granted_message">You have to accept the requested permissions to use the single sign-on feature.</string>
+
     <string name="nextcloud_http_request_failed_title">Error</string>
     <string name="nextcloud_http_request_failed_message" formatted="true">HTTP request failed with HTTP status-code: %1$d</string>
 


### PR DESCRIPTION
Fixes some issues related to the Android Account Manager. Uses a custom Auth-Dialog instead of the build-in authentication manager dialog.

Details: https://github.com/nextcloud/Android-SingleSignOn/issues/30