### PR TITLE
remove application tag

### DIFF
--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -4,6 +4,4 @@
 
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.GET_ACCOUNTS" />
-
-    <application android:label="@string/app_name" />
 </manifest>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -1,5 +1,4 @@
 <resources>
-    <string name="app_name">Nextcloud Single Sign On</string>
 
     <string name="no_current_account_selected_exception_title">Warning</string>
     <string name="no_current_account_selected_exception_message">No account selected yet</string>


### PR DESCRIPTION
This is not an application and it overwrites app_name of https://github.com/nextcloud/news-android (at least with Android Studio 3.2)