### PR TITLE
make requests wait for api to initialize properly

### DIFF
--- a/src/main/java/com/nextcloud/android/sso/api/NextcloudAPI.java
+++ b/src/main/java/com/nextcloud/android/sso/api/NextcloudAPI.java
@@ -25,6 +25,7 @@ import android.content.Intent;
 import android.content.ServiceConnection;
 import android.os.IBinder;
 import android.os.Looper;
+import android.os.NetworkOnMainThreadException;
 import android.os.ParcelFileDescriptor;
 import android.os.RemoteException;
 import android.util.Log;
@@ -273,6 +274,13 @@ public class NextcloudAPI {
      */
     private ParcelFileDescriptor performAidlNetworkRequest(NextcloudRequest request)
             throws IOException, RemoteException, NextcloudApiNotRespondingException {
+
+        // Check if we are on the main thread
+        if(Looper.myLooper() == Looper.getMainLooper()) {
+            throw new NetworkOnMainThreadException();
+        }
+
+        // Wait for api to be initialized
         waitForApi();
 
         // Log.d(TAG, request.url);

--- a/src/main/java/com/nextcloud/android/sso/api/NextcloudAPI.java
+++ b/src/main/java/com/nextcloud/android/sso/api/NextcloudAPI.java
@@ -49,6 +49,7 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Reader;
 import java.lang.reflect.Type;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import io.reactivex.Observable;
 import io.reactivex.annotations.NonNull;
@@ -76,7 +77,7 @@ public class NextcloudAPI {
 
     private Gson gson;
     private IInputStreamService mService = null;
-    private boolean mBound = false; // Flag indicating whether we have called bind on the service
+    private AtomicBoolean mBound = new AtomicBoolean(false); // Flag indicating whether we have called bind on the service
     private boolean mDestroyed = false; // Flag indicating if API is destroyed
     private SingleSignOnAccount mAccount;
     private ApiConnectedListener mCallback;
@@ -106,7 +107,7 @@ public class NextcloudAPI {
         }
 
         // Disconnect if connected
-        if (mBound) {
+        if (mBound.get()) {
             stop();
         }
 
@@ -132,13 +133,13 @@ public class NextcloudAPI {
         mCallback = null;
 
         // Unbind from the service
-        if (mBound) {
+        if (mBound.get()) {
             if (mContext != null) {
                 mContext.unbindService(mConnection);
             } else {
                 Log.e(TAG, "Context was null, cannot unbind nextcloud single sign-on service connection!");
             }
-            mBound = false;
+            mBound.set(false);
             mContext = null;
         }
     }
@@ -152,7 +153,15 @@ public class NextcloudAPI {
             Log.i(TAG, "Nextcloud Single sign-on: onServiceConnected");
 
             mService = IInputStreamService.Stub.asInterface(service);
-            mBound = true;
+            mBound.set(true);
+            try {
+                Thread.sleep(15000);
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+            synchronized (mBound) {
+                mBound.notifyAll();
+            }
             mCallback.onConnected();
         }
 
@@ -161,7 +170,7 @@ public class NextcloudAPI {
             // This is called when the connection with the service has been
             // unexpectedly disconnected -- that is, its process crashed.
             mService = null;
-            mBound = false;
+            mBound.set(false);
 
             if (!mDestroyed) {
                 connectApiWithBackoff();
@@ -169,6 +178,16 @@ public class NextcloudAPI {
         }
     };
 
+    private void waitForApi() throws InterruptedException{
+        Log.v(TAG, "[waitForApi] - called from Thread: [" + Thread.currentThread().getName() +  "]");
+        synchronized (mBound) {
+            // If service is not bound yet.. wait
+            if(!mBound.get()) {
+                Log.v(TAG, "[waitForApi] - api not ready yet.. waiting");
+                mBound.wait(10000); // wait up to 10 seconds
+            }
+        }
+    }
 
     public <T> Observable<T> performRequestObservable(final Type type, final NextcloudRequest request) {
         return Observable.fromPublisher(new Publisher<T>() {
@@ -249,7 +268,9 @@ public class NextcloudAPI {
      * @throws IOException
      */
     private ParcelFileDescriptor performAidlNetworkRequest(NextcloudRequest request)
-            throws IOException, RemoteException {
+            throws IOException, RemoteException, InterruptedException {
+        waitForApi();
+
         // Log.d(TAG, request.url);
         request.setAccountName(getAccountName());
         request.setToken(getAccountToken());

--- a/src/main/java/com/nextcloud/android/sso/api/NextcloudAPI.java
+++ b/src/main/java/com/nextcloud/android/sso/api/NextcloudAPI.java
@@ -59,9 +59,20 @@ import static com.nextcloud.android.sso.exceptions.SSOException.parseNextcloudCu
 
 public class NextcloudAPI {
 
+    private static final String TAG = NextcloudAPI.class.getCanonicalName();
+
+    private Gson gson;
+    private IInputStreamService mService = null;
+    private final AtomicBoolean mBound = new AtomicBoolean(false); // Flag indicating whether we have called bind on the service
+    private boolean mDestroyed = false; // Flag indicating if API is destroyed
+    private SingleSignOnAccount mAccount;
+    private ApiConnectedListener mCallback;
+    private Context mContext;
+
+
+
     public interface ApiConnectedListener {
         void onConnected();
-
         void onError(Exception ex);
     }
 
@@ -73,17 +84,6 @@ public class NextcloudAPI {
 
         connectApiWithBackoff();
     }
-
-    private static final String TAG = NextcloudAPI.class.getCanonicalName();
-
-    private Gson gson;
-    private IInputStreamService mService = null;
-    private final AtomicBoolean mBound = new AtomicBoolean(false); // Flag indicating whether we have called bind on the service
-    private boolean mDestroyed = false; // Flag indicating if API is destroyed
-    private SingleSignOnAccount mAccount;
-    private ApiConnectedListener mCallback;
-    private Context mContext;
-
 
     private String getAccountName() {
         return mAccount.name;

--- a/src/main/java/com/nextcloud/android/sso/exceptions/NextcloudApiNotRespondingException.java
+++ b/src/main/java/com/nextcloud/android/sso/exceptions/NextcloudApiNotRespondingException.java
@@ -1,0 +1,18 @@
+package com.nextcloud.android.sso.exceptions;
+
+import android.content.Context;
+
+import com.nextcloud.android.sso.R;
+import com.nextcloud.android.sso.model.ExceptionMessage;
+
+public class NextcloudApiNotRespondingException extends SSOException {
+
+    @Override
+    public void loadExceptionMessage(Context context) {
+        this.em = new ExceptionMessage(
+                context.getString(R.string.nextcloud_files_api_not_responsing_title),
+                context.getString(R.string.nextcloud_files_api_not_responsing_message)
+        );
+    }
+
+}

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -30,6 +30,10 @@
     <string name="nextcloud_files_app_not_supported_title">Error</string>
     <string name="nextcloud_files_app_not_supported_message" formatted="true">Your nextcloud files app currently does not support the single sign on feature. Please update it: %1$s</string>
 
+
+    <string name="nextcloud_files_api_not_responsing_title">Error</string>
+    <string name="nextcloud_files_api_not_responsing_message">Nextcloud files app api is not responding. Please report this issue.</string>
+
     <string name="select_account_unknown_error_toast">Something went wrong.. please try again</string>
 
 </resources>


### PR DESCRIPTION
As mentioned [here](https://github.com/nextcloud/news-android/issues/713#issuecomment-450154817), when making requests right after starting the NextcloudAPI, the request will fail with the following error message: 

```
Attempt to invoke interface method 'android.os.ParcelFileDescriptor com.nextcloud.android.sso.aidl.IInputStreamService.performNextcloudRequest(android.os.ParcelFileDescriptor)' on a null object reference
```

This happens because the service, which is used for passing the actual network request to the files app is not started/bound at that very moment. Therefore we need to wait for the service to be bound. 

This PR adds a check before each call waiting for the API to be initialized. If the API is not ready within 10 seconds, the request will fail and a `NextcloudApiNotRespondingException` will be thrown.

Let me know what you think! 