### PR TITLE
create account object when account list is empty

### DIFF
--- a/src/main/java/com/nextcloud/android/sso/AccountImporter.java
+++ b/src/main/java/com/nextcloud/android/sso/AccountImporter.java
@@ -110,7 +110,7 @@ public class AccountImporter {
                 return account;
             }
         }
-        return null;
+        return new Account(name,"nextcloud");
     }
 
     public static void clearAllAuthTokens(Context context) {


### PR DESCRIPTION
Hi,

On android 7 nextcloud crashes after getting permission because AccountManager.getAccounts() returns an empty list on the SSO library

this is a quick fix (it works) but perhaps a bad one

what do you think ?

Thanks ! 