### PR TITLE
Rename username to userId

### DIFF
--- a/src/main/java/com/nextcloud/android/sso/AccountImporter.java
+++ b/src/main/java/com/nextcloud/android/sso/AccountImporter.java
@@ -150,13 +150,13 @@ public class AccountImporter {
         Bundle future = intent.getBundleExtra(NEXTCLOUD_SSO);
 
         String accountName = future.getString(AccountManager.KEY_ACCOUNT_NAME);
-        String username = future.getString(Constants.SSO_USERNAME);
+        String userId = future.getString(Constants.SSO_USER_ID);
         String token = future.getString(Constants.SSO_TOKEN);
-        String server_url = future.getString(Constants.SSO_SERVER_URL);
+        String serverUrl = future.getString(Constants.SSO_SERVER_URL);
 
         SharedPreferences mPrefs = getSharedPreferences(context);
         String prefKey = getPrefKeyForAccount(accountName);
-        SingleSignOnAccount ssoAccount = new SingleSignOnAccount(accountName, username, token, server_url);
+        SingleSignOnAccount ssoAccount = new SingleSignOnAccount(accountName, userId, token, serverUrl);
         try {
             mPrefs.edit().putString(prefKey, SingleSignOnAccount.toString(ssoAccount)).apply();
         } catch (IOException e) {

--- a/src/main/java/com/nextcloud/android/sso/AccountImporter.java
+++ b/src/main/java/com/nextcloud/android/sso/AccountImporter.java
@@ -151,6 +151,10 @@ public class AccountImporter {
 
         String accountName = future.getString(AccountManager.KEY_ACCOUNT_NAME);
         String userId = future.getString(Constants.SSO_USER_ID);
+        if (userId == null) {
+            // backwards compatibility
+            userId = future.getString("username");
+        }
         String token = future.getString(Constants.SSO_TOKEN);
         String serverUrl = future.getString(Constants.SSO_SERVER_URL);
 

--- a/src/main/java/com/nextcloud/android/sso/Constants.java
+++ b/src/main/java/com/nextcloud/android/sso/Constants.java
@@ -22,7 +22,7 @@ package com.nextcloud.android.sso;
 public class Constants {
 
     // Authenticator related constants
-    public static final String SSO_USERNAME = "username";
+    public static final String SSO_USER_ID = "user_id";
     public static final String SSO_TOKEN = "token";
     public static final String SSO_SERVER_URL = "server_url";
     public static final String SSO_SHARED_PREFERENCE = "single-sign-on";

--- a/src/main/java/com/nextcloud/android/sso/model/SingleSignOnAccount.java
+++ b/src/main/java/com/nextcloud/android/sso/model/SingleSignOnAccount.java
@@ -34,13 +34,13 @@ public class SingleSignOnAccount implements Serializable {
     private static final long serialVersionUID = 21523240203234240L; //assign a long value
 
     public String name; // Name of the account in android
-    public String username;
+    public String userId;
     public String token;
     public String url;
 
-    public SingleSignOnAccount(String name, String username, String token, String url) {
+    public SingleSignOnAccount(String name, String userId, String token, String url) {
         this.name = name;
-        this.username = username;
+        this.userId = userId;
         this.token = token;
         this.url = url;
     }


### PR DESCRIPTION
To clarify and have it in sync across all projects:
userId: internally id, needed for e.g. dav/trashbin/$userId/

loginName: used for authenticate on every login/network connection, determinated by first login (weblogin/old login): can be anything: email, name, name with withespaces

displayName: Name chosen by user, only displayed, no usage at all

There will be soon a matching PR in library/files

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>