### PR TITLE
Remove rxandroid

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,9 +58,6 @@ dependencies {
 
     implementation 'com.google.code.gson:gson:2.8.5'
 
-    implementation 'io.reactivex.rxjava2:rxandroid:2.0.1'
-    // Because RxAndroid releases are few and far between, it is recommended you also
-    // explicitly depend on RxJava's latest version for bug fixes and new features.
     implementation 'io.reactivex.rxjava2:rxjava:2.1.4'
 
     implementation 'commons-io:commons-io:2.6'


### PR DESCRIPTION
It's not used and since its main purpose is related to android main thread we probably won't ever.