### PR TITLE
Fix account not found - Fix #60

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,13 @@ public void onActivityResult(int requestCode, int resultCode, Intent data) {
     }
 }
 
+@Override
+public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
+    super.onRequestPermissionsResult(requestCode, permissions, grantResults);
+
+    AccountImporter.onRequestPermissionsResult(requestCode, permissions, grantResults, this);
+}
+
 // Complete example: https://github.com/nextcloud/news-android/blob/master/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/LoginDialogFragment.java
 ```
 
@@ -250,7 +257,7 @@ if (VersionCheckHelper.verifyMinVersion(context, MIN_NEXTCLOUD_FILES_APP_VERSION
 }
 ``` 
 
-## Nextcloud Conference 2018 Talk
+## Nextcloud Conference 2018 Talk (5min)
 
 [![Nextcloud Single Sign On for Android David Luhmer](https://img.youtube.com/vi/gnLOwmrJLUw/0.jpg)](https://www.youtube.com/watch?v=gnLOwmrJLUw)
 

--- a/src/main/java/com/nextcloud/android/sso/exceptions/AndroidGetAccountsPermissionNotGranted.java
+++ b/src/main/java/com/nextcloud/android/sso/exceptions/AndroidGetAccountsPermissionNotGranted.java
@@ -1,0 +1,17 @@
+package com.nextcloud.android.sso.exceptions;
+
+import android.content.Context;
+
+import com.nextcloud.android.sso.R;
+import com.nextcloud.android.sso.model.ExceptionMessage;
+
+public class AndroidGetAccountsPermissionNotGranted extends SSOException {
+
+    @Override
+    public void loadExceptionMessage(Context context) {
+        this.em = new ExceptionMessage(
+             context.getString(R.string.android_get_accounts_permission_not_granted_exception_title),
+             context.getString(R.string.android_get_accounts_permission_not_granted_exception_message)
+        );
+    }
+}

--- a/src/main/java/com/nextcloud/android/sso/exceptions/CurrentAccountNotFoundException.java
+++ b/src/main/java/com/nextcloud/android/sso/exceptions/CurrentAccountNotFoundException.java
@@ -29,8 +29,8 @@ public class CurrentAccountNotFoundException extends SSOException {
     @Override
     public void loadExceptionMessage(Context context) {
         this.em = new ExceptionMessage(
-            em.title   = context.getString(R.string.current_account_not_found_exception_title),
-            em.message = context.getString(R.string.current_account_not_found_exception_message)
+            context.getString(R.string.current_account_not_found_exception_title),
+            context.getString(R.string.current_account_not_found_exception_message)
         );
     }
 }

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -3,6 +3,9 @@
     <string name="no_current_account_selected_exception_title">Warning</string>
     <string name="no_current_account_selected_exception_message">No account selected yet</string>
 
+    <string name="android_get_accounts_permission_not_granted_exception_title">Error</string>
+    <string name="android_get_accounts_permission_not_granted_exception_message">In order to use the Nextcloud Single-Sign-On on this device, you need to grant permission to access your accounts</string>
+
     <string name="current_account_not_found_exception_title">Warning</string>
     <string name="current_account_not_found_exception_message">Selected account was not found. Something went wrong..</string>
 


### PR DESCRIPTION
Fixes #60

Android API < 8 requires `GET_ACCOUNTS` permission.

https://developer.android.com/reference/android/accounts/AccountManager#getAccountsByType(java.lang.String)

We really should move away from using the android account manager at all.. This makes things way easier and cleaner! (#49)