### PR TITLE
Prevent crash if for some, unknown, reason, mCallback is null

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -130,7 +130,7 @@ detekt {
 
 dependencies {
 
-    implementation "androidx.appcompat:appcompat:1.1.0"
+    implementation "androidx.appcompat:appcompat:1.0.2"
     implementation 'androidx.annotation:annotation:1.1.0'
     implementation 'androidx.core:core:1.1.0'
     implementation 'androidx.fragment:fragment:1.1.0'

--- a/build.gradle
+++ b/build.gradle
@@ -130,7 +130,7 @@ detekt {
 
 dependencies {
 
-    implementation "androidx.appcompat:appcompat:1.0.2"
+    implementation "androidx.appcompat:appcompat:1.1.0"
     implementation 'androidx.annotation:annotation:1.1.0'
     implementation 'androidx.core:core:1.1.0'
     implementation 'androidx.fragment:fragment:1.1.0'

--- a/src/main/java/com/nextcloud/android/sso/api/AidlNetworkRequest.java
+++ b/src/main/java/com/nextcloud/android/sso/api/AidlNetworkRequest.java
@@ -52,7 +52,11 @@ public class AidlNetworkRequest extends NetworkRequest {
             synchronized (mBound) {
                 mBound.notifyAll();
             }
-            mCallback.onConnected();
+
+            if (null != mCallback)
+            {
+                mCallback.onConnected();
+            }
         }
 
         public void onServiceDisconnected(ComponentName className) {

--- a/src/main/java/com/nextcloud/android/sso/api/AidlNetworkRequest.java
+++ b/src/main/java/com/nextcloud/android/sso/api/AidlNetworkRequest.java
@@ -95,7 +95,10 @@ public class AidlNetworkRequest extends NetworkRequest {
             }
         } catch (SecurityException e) {
             Log.e(TAG, "can't bind to AccountManagerService, check permission in Manifest");
-            mCallback.onError(e);
+            if (null != mCallback)
+            {
+                mCallback.onError(e);
+            }
         }
     }
 


### PR DESCRIPTION
I don't know why it happened but I got an App crash because mCallback was null.  This was how my code looked when the API is created.
```

private NextcloudAPI.ApiConnectedListener mNextCloudApiCallback = new NextcloudAPI.ApiConnectedListener()
    {
        @Override
        public void onConnected()
        {
        }
        @Override
        public void onError(Exception ex)
        {
        }
    };

```
And this:
`
mNextcloudAPI = new NextcloudAPI(a_context, mSignInAccount, 
                                     new GsonBuilder().create(), mNextCloudApiCallback);
 `

I don't know why it happened but I put a check into AidlNetworkRequest to check for the condition and have not, yet, been able to re-create the crash.  I'm not saying this fixes the problem since I'm still testing it but thought I'd pass it along for you all to think about.