### PR TITLE
throw exception if SSO import is cancelled

### DIFF
--- a/src/main/java/com/nextcloud/android/sso/AccountImporter.java
+++ b/src/main/java/com/nextcloud/android/sso/AccountImporter.java
@@ -34,10 +34,7 @@ import android.os.Bundle;
 import android.util.Log;
 import android.widget.Toast;
 
-import androidx.core.app.ActivityCompat;
-import androidx.core.content.ContextCompat;
-import androidx.fragment.app.Fragment;
-
+import com.nextcloud.android.sso.exceptions.AccountImportCancelledException;
 import com.nextcloud.android.sso.exceptions.AndroidGetAccountsPermissionNotGranted;
 import com.nextcloud.android.sso.exceptions.NextcloudFilesAppAccountNotFoundException;
 import com.nextcloud.android.sso.exceptions.NextcloudFilesAppAccountPermissionNotGrantedException;
@@ -52,6 +49,9 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import androidx.core.app.ActivityCompat;
+import androidx.core.content.ContextCompat;
+import androidx.fragment.app.Fragment;
 import io.reactivex.annotations.NonNull;
 
 import static android.app.Activity.RESULT_CANCELED;
@@ -221,17 +221,18 @@ public class AccountImporter {
     }
 
     public static void onActivityResult(int requestCode, int resultCode, Intent data, Activity activity,
-                                        IAccountAccessGranted callback) {
+                                        IAccountAccessGranted callback) throws AccountImportCancelledException {
         onActivityResult(requestCode, resultCode, data, activity, null, callback);
     }
 
     public static void onActivityResult(int requestCode, int resultCode, Intent data, Fragment fragment,
-                                        IAccountAccessGranted callback) {
+                                        IAccountAccessGranted callback) throws AccountImportCancelledException {
         onActivityResult(requestCode, resultCode, data, null, fragment, callback);
     }
 
     private static void onActivityResult(int requestCode, int resultCode, Intent data, Activity activity,
-                                         Fragment fragment, IAccountAccessGranted callback) {
+                                         Fragment fragment, IAccountAccessGranted callback) 
+    throws AccountImportCancelledException {
         Context context = (activity != null) ? activity : fragment.getContext();
 
         if (resultCode == RESULT_OK) {
@@ -268,8 +269,8 @@ public class AccountImporter {
         } else if (resultCode == RESULT_CANCELED) {
             switch (requestCode) {
                 case CHOOSE_ACCOUNT_SSO:
-                    Toast.makeText(context, R.string.select_account_unknown_error_toast, Toast.LENGTH_LONG).show();
-                    break;
+                    // nothing to do here
+                    throw new AccountImportCancelledException();
                 case REQUEST_AUTH_TOKEN_SSO:
                     try {
                         handleFailedAuthRequest(data);

--- a/src/main/java/com/nextcloud/android/sso/exceptions/AccountImportCancelledException.java
+++ b/src/main/java/com/nextcloud/android/sso/exceptions/AccountImportCancelledException.java
@@ -1,0 +1,36 @@
+package com.nextcloud.android.sso.exceptions;
+
+import android.content.Context;
+
+import com.nextcloud.android.sso.R;
+import com.nextcloud.android.sso.model.ExceptionMessage;
+
+/**
+ *  Nextcloud SingleSignOn
+ *
+ *  @author Tobias Kaminsky
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+public class AccountImportCancelledException extends SSOException {
+
+    @Override
+    public void loadExceptionMessage(Context context) {
+        this.em = new ExceptionMessage(
+                context.getString(R.string.sso_canceled),
+                context.getString(R.string.sso_canceled_message)
+        );
+    }
+}

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -38,5 +38,7 @@
     <string name="nextcloud_files_api_not_responsing_message">Nextcloud files app api is not responding. Please report this issue.</string>
 
     <string name="select_account_unknown_error_toast">Something went wrong.. please try again</string>
+    <string name="sso_canceled">SSO import canceled</string>
+    <string name="sso_canceled_message">SSO import was cancelled by user</string>
 
 </resources>


### PR DESCRIPTION
Fix https://github.com/nextcloud/Android-SingleSignOn/issues/124

@David-Development this is a breaking change (the 3rd party user have to catch the exception).

I will add this to release notes.