### PR TITLE
Downgrade retrofit to Version 2.6.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -144,8 +144,12 @@ dependencies {
 
     implementation 'commons-io:commons-io:2.6'
 
-    implementation 'com.squareup.retrofit2:retrofit:2.7.1'
-    implementation 'com.squareup.okhttp3:okhttp:3.12.8' // 3.13+ requires Lollipop, but our minSdkVersion is 14
+    implementation ('com.squareup.retrofit2:retrofit:2.6.4') {
+        because '2.7.0 requires okhttp:3.14.x which requires API level 19'
+    }
+    implementation ('com.squareup.okhttp3:okhttp:3.12.8') {
+        because '3.13+ requires Lollipop, but our minSdkVersion is 14'
+    }
 
     spotbugsPlugins 'com.h3xstream.findsecbugs:findsecbugs-plugin:1.10.1'
     spotbugsPlugins 'com.mebigfatguy.fb-contrib:fb-contrib:7.4.7'

--- a/src/main/java/com/nextcloud/android/sso/helper/BufferedSourceSSO.java
+++ b/src/main/java/com/nextcloud/android/sso/helper/BufferedSourceSSO.java
@@ -45,10 +45,12 @@ public class BufferedSourceSSO implements BufferedSource {
         throw new UnsupportedOperationException("Not implemented");
     }
 
+    /*
     @Override
     public Buffer getBuffer() {
         return buffer();
     }
+    */
 
     @Override
     public boolean exhausted() throws IOException {
@@ -251,10 +253,12 @@ public class BufferedSourceSSO implements BufferedSource {
         throw new UnsupportedOperationException("Not implemented");
     }
 
+    /*
     @Override
     public BufferedSource peek() {
         throw new UnsupportedOperationException("Not implemented");
     }
+    */
 
     @Override
     public InputStream inputStream() {


### PR DESCRIPTION
Retrofit 2.7.0 uses okhttp:3.14.x which is incompatible with our minsdk

Signed-off-by: David Luhmer <david-dev@live.de>