### PR TITLE
ExceptionMessage should implement Serializable

### DIFF
--- a/src/main/java/com/nextcloud/android/sso/model/ExceptionMessage.java
+++ b/src/main/java/com/nextcloud/android/sso/model/ExceptionMessage.java
@@ -1,5 +1,7 @@
 package com.nextcloud.android.sso.model;
 
+import java.io.Serializable;
+
 /**
  *  Nextcloud SingleSignOn
  *
@@ -19,7 +21,7 @@ package com.nextcloud.android.sso.model;
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-public class ExceptionMessage {
+public class ExceptionMessage implements Serializable {
 
     public String title;
     public String message;


### PR DESCRIPTION
Fixes this exception (A bit hard to reproduce, but i get it when i pass `SSOException` to a fragment and start e. g. a web browser intent from this fragment and the activity gets stopped):

```
2020-05-07 19:52:28.526 23303-23303/it.niedermann.nextcloud.deck.dev E/AndroidRuntime: FATAL EXCEPTION: main
    Process: it.niedermann.nextcloud.deck.dev, PID: 23303
    java.lang.RuntimeException: Parcelable encountered IOException writing serializable object (name = com.nextcloud.android.sso.exceptions.NextcloudHttpRequestFailedException)
        at android.os.Parcel.writeSerializable(Parcel.java:1833)
        at android.os.Parcel.writeValue(Parcel.java:1780)
        at android.os.Parcel.writeArrayMapInternal(Parcel.java:928)
        at android.os.BaseBundle.writeToParcelInner(BaseBundle.java:1584)
        at android.os.Bundle.writeToParcel(Bundle.java:1253)
        at android.os.Parcel.writeBundle(Parcel.java:997)
        at androidx.fragment.app.FragmentState.writeToParcel(FragmentState.java:125)
        at android.os.Parcel.writeTypedObject(Parcel.java:1634)
        at android.os.Parcel.writeTypedList(Parcel.java:1513)
        at android.os.Parcel.writeTypedList(Parcel.java:1470)
        at androidx.fragment.app.FragmentManagerState.writeToParcel(FragmentManagerState.java:51)
        at android.os.Parcel.writeParcelable(Parcel.java:1801)
        at android.os.Parcel.writeValue(Parcel.java:1707)
        at android.os.Parcel.writeArrayMapInternal(Parcel.java:928)
        at android.os.BaseBundle.writeToParcelInner(BaseBundle.java:1584)
        at android.os.Bundle.writeToParcel(Bundle.java:1253)
        at android.app.IActivityTaskManager$Stub$Proxy.activityStopped(IActivityTaskManager.java:4505)
        at android.app.servertransaction.PendingTransactionActions$StopInfo.run(PendingTransactionActions.java:145)
        at android.os.Handler.handleCallback(Handler.java:883)
        at android.os.Handler.dispatchMessage(Handler.java:100)
        at android.os.Looper.loop(Looper.java:214)
        at android.app.ActivityThread.main(ActivityThread.java:7356)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:492)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:930)
     Caused by: java.io.NotSerializableException: com.nextcloud.android.sso.model.ExceptionMessage
        at java.io.ObjectOutputStream.writeObject0(ObjectOutputStream.java:1240)
        at java.io.ObjectOutputStream.defaultWriteFields(ObjectOutputStream.java:1604)
        at java.io.ObjectOutputStream.writeSerialData(ObjectOutputStream.java:1565)
        at java.io.ObjectOutputStream.writeOrdinaryObject(ObjectOutputStream.java:1488)
        at java.io.ObjectOutputStream.writeObject0(ObjectOutputStream.java:1234)
        at java.io.ObjectOutputStream.writeObject(ObjectOutputStream.java:354)
        at android.os.Parcel.writeSerializable(Parcel.java:1828)
        at android.os.Parcel.writeValue(Parcel.java:1780) 
        at android.os.Parcel.writeArrayMapInternal(Parcel.java:928) 
        at android.os.BaseBundle.writeToParcelInner(BaseBundle.java:1584) 
        at android.os.Bundle.writeToParcel(Bundle.java:1253) 
        at android.os.Parcel.writeBundle(Parcel.java:997) 
        at androidx.fragment.app.FragmentState.writeToParcel(FragmentState.java:125) 
        at android.os.Parcel.writeTypedObject(Parcel.java:1634) 
        at android.os.Parcel.writeTypedList(Parcel.java:1513) 
        at android.os.Parcel.writeTypedList(Parcel.java:1470) 
        at androidx.fragment.app.FragmentManagerState.writeToParcel(FragmentManagerState.java:51) 
        at android.os.Parcel.writeParcelable(Parcel.java:1801) 
        at android.os.Parcel.writeValue(Parcel.java:1707) 
        at android.os.Parcel.writeArrayMapInternal(Parcel.java:928) 
        at android.os.BaseBundle.writeToParcelInner(BaseBundle.java:1584) 
        at android.os.Bundle.writeToParcel(Bundle.java:1253) 
        at android.app.IActivityTaskManager$Stub$Proxy.activityStopped(IActivityTaskManager.java:4505) 
        at android.app.servertransaction.PendingTransactionActions$StopInfo.run(PendingTransactionActions.java:145) 
        at android.os.Handler.handleCallback(Handler.java:883) 
        at android.os.Handler.dispatchMessage(Handler.java:100) 
        at android.os.Looper.loop(Looper.java:214) 
        at android.app.ActivityThread.main(ActivityThread.java:7356) 
        at java.lang.reflect.Method.invoke(Native Method) 
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:492) 
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:930) 

```