### PR TITLE
Update tests for V2

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,4 +1,46 @@
 kind: pipeline
+type: docker
+name: tests
+
+steps:
+  - name: gplay
+    image: nextcloudci/android:android-49
+    environment:
+      LOG_USERNAME:
+        from_secret: LOG_USERNAME
+      LOG_PASSWORD:
+        from_secret: LOG_PASSWORD
+      GIT_USERNAME:
+        from_secret: GIT_USERNAME
+      GIT_TOKEN:
+        from_secret: GIT_TOKEN
+      ORG_GRADLE_PROJECT_coverage: ''
+    commands:
+      - ./gradlew assemble
+      - ./gradlew test
+  - name: notify
+    image: drillster/drone-email
+    settings:
+      port: 587
+      from: nextcloud-drone@kaminsky.me
+      recipients_only: true
+      username:
+        from_secret: EMAIL_USERNAME
+      password:
+        from_secret: EMAIL_PASSWORD
+      recipients:
+        from_secret: EMAIL_RECIPIENTS
+      host:
+        from_secret: EMAIL_HOST
+    when:
+      event:
+        - push
+      status:
+        - failure
+      branch:
+        - master
+---
+kind: pipeline
 name: analysis
 
 steps:

--- a/src/test/java/com/nextcloud/android/sso/api/TestRetrofitAPI.java
+++ b/src/test/java/com/nextcloud/android/sso/api/TestRetrofitAPI.java
@@ -20,6 +20,7 @@ import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
+import io.reactivex.Observable;
 import okhttp3.ResponseBody;
 import retrofit2.Call;
 import retrofit2.Callback;
@@ -32,6 +33,7 @@ import static org.junit.Assert.assertNotEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -57,7 +59,8 @@ public class TestRetrofitAPI {
 
     @Before
     public void setUp() {
-        when(nextcloudApiMock.getGson()).thenReturn(new GsonBuilder().create());
+        lenient().when(nextcloudApiMock.getGson()).thenReturn(new GsonBuilder().create());
+        lenient().when(nextcloudApiMock.performRequestObservableV2(any(), any())).thenReturn(Observable.empty());
         mApi = new NextcloudRetrofitApiBuilder(nextcloudApiMock, mApiEndpoint).create(API.class);
     }
 
@@ -107,7 +110,7 @@ public class TestRetrofitAPI {
 
         Type type = new TypeToken<List<String>>() {}.getType();
         try {
-            verify(nextcloudApiMock).performRequest(eq(type), eq(request));
+            verify(nextcloudApiMock).performRequestV2(eq(type), eq(request));
         } catch (Exception e) {
             fail(e.getMessage());
         }
@@ -132,7 +135,7 @@ public class TestRetrofitAPI {
 
         Type type = new TypeToken<Void>(){}.getType();
         try {
-            verify(nextcloudApiMock).performRequest(eq(type), eq(request));
+            verify(nextcloudApiMock).performRequestV2(eq(type), eq(request));
         } catch (Exception e) {
             fail(e.getMessage());
         }
@@ -152,7 +155,7 @@ public class TestRetrofitAPI {
 
         Type type = new TypeToken<Void>() {}.getType();
         try {
-            verify(nextcloudApiMock).performRequest(eq(type), eq(request));
+            verify(nextcloudApiMock).performRequestV2(eq(type), eq(request));
         } catch (Exception e) {
             fail(e.getMessage());
         }
@@ -192,7 +195,7 @@ public class TestRetrofitAPI {
 
         Type type = new TypeToken<List<String>>() {}.getType();
         try {
-            verify(nextcloudApiMock).performRequest(eq(type), eq(request));
+            verify(nextcloudApiMock).performRequestV2(eq(type), eq(request));
         } catch (Exception e) {
             fail(e.getMessage());
         }
@@ -252,7 +255,7 @@ public class TestRetrofitAPI {
 
         Type type = new TypeToken<Void>() {}.getType();
         try {
-            verify(nextcloudApiMock).performRequest(eq(type), eq(request));
+            verify(nextcloudApiMock).performRequestV2(eq(type), eq(request));
         } catch (Exception e) {
             fail(e.getMessage());
         }
@@ -342,7 +345,7 @@ public class TestRetrofitAPI {
 
         Type type = new TypeToken<Void>() {}.getType();
         try {
-            verify(nextcloudApiMock).performRequest(eq(type), eq(request));
+            verify(nextcloudApiMock).performRequestV2(eq(type), eq(request));
         } catch (Exception e) {
             fail(e.getMessage());
         }
@@ -369,7 +372,7 @@ public class TestRetrofitAPI {
 
         Type type = new TypeToken<Void>() {}.getType();
         try {
-            verify(nextcloudApiMock).performRequest(eq(type), eq(request));
+            verify(nextcloudApiMock).performRequestV2(eq(type), eq(request));
         } catch (Exception e) {
             fail(e.getMessage());
         }
@@ -394,7 +397,7 @@ public class TestRetrofitAPI {
 
         Type type = new TypeToken<ResponseBody>() {}.getType();
         try {
-            verify(nextcloudApiMock).performRequest(eq(type), eq(request));
+            verify(nextcloudApiMock).performRequestV2(eq(type), eq(request));
         } catch (Exception e) {
             fail(e.getMessage());
         }
@@ -420,7 +423,7 @@ public class TestRetrofitAPI {
 
         Type type = new TypeToken<ResponseBody>() {}.getType();
         try {
-            verify(nextcloudApiMock).performRequest(eq(type), eq(request));
+            verify(nextcloudApiMock).performRequestV2(eq(type), eq(request));
         } catch (Exception e) {
             fail(e.getMessage());
         }
@@ -447,7 +450,7 @@ public class TestRetrofitAPI {
 
         Type type = new TypeToken<ResponseBody>() {}.getType();
         try {
-            verify(nextcloudApiMock).performRequest(eq(type), eq(request));
+            verify(nextcloudApiMock).performRequestV2(eq(type), eq(request));
         } catch (Exception e) {
             fail(e.getMessage());
         }


### PR DESCRIPTION
Added lenient to suppress unused MockitoHints (which seem to be wrong) as at least the second stub is needed to pass tests again.
```
[MockitoHint] 1. Unused -> at com.nextcloud.android.sso.api.TestRetrofitAPI.setUp(TestRetrofitAPI.java:61)
[MockitoHint] 2. Unused -> at com.nextcloud.android.sso.api.TestRetrofitAPI.setUp(TestRetrofitAPI.java:62)
```

@tobiasKaminsky You maybe want to continue on #77 as drone still doesn't compile or execute tests.