### PR TITLE
Restore breaking change of 0.5.5

### DIFF
--- a/src/main/java/com/nextcloud/android/sso/helper/VersionCheckHelper.java
+++ b/src/main/java/com/nextcloud/android/sso/helper/VersionCheckHelper.java
@@ -49,6 +49,14 @@ public final class VersionCheckHelper {
         return false;
     }
 
+    /**
+     * @deprecated use {@link #getNextcloudFilesVersionCode(Context, boolean)}
+     */
+    @Deprecated
+    public static int getNextcloudFilesVersionCode(Context context) throws PackageManager.NameNotFoundException {
+        return getNextcloudFilesVersionCode(context, true);
+    }
+
     public static int getNextcloudFilesVersionCode(Context context, boolean prod) throws PackageManager.NameNotFoundException {
         PackageInfo pInfo = context.getPackageManager().getPackageInfo(prod ? Constants.PACKAGE_NAME_PROD : Constants.PACKAGE_NAME_DEV, 0);
         int verCode = pInfo.versionCode;


### PR DESCRIPTION
Version `0.5.5` introduced a **breaking change**. In terms of semantic versioning this means a bug.

This PR restores the compatibility with older versions by adding a shim for the changed method and mark it as `@Deprecated`. It can safely be removed as soon as we jump to `0.6.0` or `1.0.0` (which we should do for marketing reasons).