### PR TITLE
Use github_token for auto approve

### DIFF
--- a/.github/workflows/autoApproveDependabot.yml
+++ b/.github/workflows/autoApproveDependabot.yml
@@ -8,4 +8,4 @@ jobs:
             - uses: hmarr/auto-approve-action@v2.0.0
               if: github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]'
               with:
-                  github-token: "${{ secrets.DEPENDABOT_AUTOMERGE_TOKEN }}"
+                  github-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
According to https://github.com/hmarr/auto-approve-action we can also use github_token here.

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>