### PR TITLE
Add Query-Requirement for Android 11 and later

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,15 @@ compileOptions {
 
 We use some features from Java 8, so your project needs also to be compiled with (at least) this version.
 
+For Android 11 and later you may need to add queries to your app's manifest file. It will not find the nextcloud-app otherwise.
+
+```
+   <queries>
+      <package android:name="com.nextcloud.client" />
+      <package android:name="com.nextcloud.android.beta" />
+   </queries>
+```
+
 ### 2) To choose an account, include the following code in your login dialog:
 
 From an Activity


### PR DESCRIPTION
Further information on the issue and source:
https://stackoverflow.com/questions/62345805/namenotfoundexception-when-calling-getpackageinfo-on-android-11