### PR TITLE
#401 Provide convenience classes for OCS requests

### DIFF
--- a/lib/src/main/java/com/nextcloud/android/sso/api/NextcloudAPI.java
+++ b/lib/src/main/java/com/nextcloud/android/sso/api/NextcloudAPI.java
@@ -86,7 +86,7 @@ public class NextcloudAPI {
 
     /**
      * <blockquote>
-     * If you need to make multiple calls, keep the NextcloudAPI open as long as you
+     * If you need to make multiple calls, keep the {@link NextcloudAPI} open as long as you
      * can. This way the services will stay active and the connection between the
      * files app and your app is already established when you make subsequent requests.
      * Otherwise you'll have to bind to the service again and again for each request.

--- a/lib/src/main/java/com/nextcloud/android/sso/api/NextcloudAPI.java
+++ b/lib/src/main/java/com/nextcloud/android/sso/api/NextcloudAPI.java
@@ -22,6 +22,7 @@ package com.nextcloud.android.sso.api;
 import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
+import android.app.Activity;
 import android.content.Context;
 import android.util.Log;
 
@@ -83,6 +84,18 @@ public class NextcloudAPI {
         new Thread(NextcloudAPI.this.networkRequest::connectApiWithBackoff).start();
     }
 
+    /**
+     * <blockquote>
+     * If you need to make multiple calls, keep the NextcloudAPI open as long as you
+     * can. This way the services will stay active and the connection between the
+     * files app and your app is already established when you make subsequent requests.
+     * Otherwise you'll have to bind to the service again and again for each request.
+     * <cite><a href="https://github.com/nextcloud/Android-SingleSignOn/issues/120#issuecomment-540069990">Source</a></cite>
+     * </blockquote>
+     *
+     * <p>A good place <em>depending on your actual implementation</em> might be {@link Activity#onStop()}.</p>
+     */
+    @SuppressWarnings("JavadocReference")
     public void stop() {
         gson = null;
         networkRequest.stop();
@@ -155,17 +168,17 @@ public class NextcloudAPI {
         return result;
     }
 
-     /**
-      * The InputStreams needs to be closed after reading from it
-      *
-      * @deprecated Use {@link #performNetworkRequestV2(NextcloudRequest)}
+    /**
+     * The InputStreams needs to be closed after reading from it
+     *
+     * @param request {@link NextcloudRequest} request to be executed on server via Files app
+     * @return InputStream answer from server as InputStream
+     * @throws Exception or {@link SSOException}
      * @see <a href="https://github.com/nextcloud/Android-SingleSignOn/issues/133">Issue #133</a>
-      * @param request {@link NextcloudRequest} request to be executed on server via Files app
-      * @return InputStream answer from server as InputStream
-      * @throws Exception or {@link SSOException}
+     * @deprecated Use {@link #performNetworkRequestV2(NextcloudRequest)}
      */
-     @Deprecated
-     public InputStream performNetworkRequest(NextcloudRequest request) throws Exception {
+    @Deprecated
+    public InputStream performNetworkRequest(NextcloudRequest request) throws Exception {
         return networkRequest.performNetworkRequest(request, request.getBodyAsStream());
     }
 

--- a/lib/src/main/java/com/nextcloud/android/sso/model/ocs/OcsCapabilitiesResponse.java
+++ b/lib/src/main/java/com/nextcloud/android/sso/model/ocs/OcsCapabilitiesResponse.java
@@ -1,0 +1,58 @@
+package com.nextcloud.android.sso.model.ocs;
+
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * <p>This is a basic implementation for the <code>capabilities</code> endpoint which maps version and theming properties.<br>
+ * You can use it directly in combination with {@link OcsResponse} or extend it.</p>
+ * <p>Example usage with Retrofit:</p>
+ * <pre>
+ * {@code
+ * @GET("/ocs/v2.php/cloud/capabilities?format=json")
+ * Call<OcsResponse<OcsCapabilities>> getCapabilities();
+ * }
+ * </pre>
+ *
+ * @see <a href="https://docs.nextcloud.com/server/latest/developer_manual//client_apis/OCS/ocs-api-overview.html#capabilities-api">Capabilities API</a>
+ */
+@SuppressWarnings("unused, SpellCheckingInspection")
+public class OcsCapabilitiesResponse {
+    public OcsVersion version;
+    public OcsCapabilities capabilities;
+
+    public static class OcsVersion {
+        public int major;
+        public int minor;
+        public int macro;
+        public String string;
+        public String edition;
+        public boolean extendedSupport;
+    }
+
+    public static class OcsCapabilities {
+        public OcsTheming theming;
+
+        public static class OcsTheming {
+            public String name;
+            public String url;
+            public String slogan;
+            public String color;
+            @SerializedName("color-text")
+            public String colorText;
+            @SerializedName("color-element")
+            public String cnextcloudapiolorElement;
+            @SerializedName("color-element-bright")
+            public String colorElementBright;
+            @SerializedName("color-element-dark")
+            public String colorElementDark;
+            public String logo;
+            public String background;
+            @SerializedName("background-plain")
+            public boolean backgroundPlain;
+            @SerializedName("background-default")
+            public boolean backgroundDefault;
+            public String logoheader;
+            public String favicon;
+        }
+    }
+}

--- a/lib/src/main/java/com/nextcloud/android/sso/model/ocs/OcsCapabilitiesResponse.java
+++ b/lib/src/main/java/com/nextcloud/android/sso/model/ocs/OcsCapabilitiesResponse.java
@@ -13,7 +13,7 @@ import com.google.gson.annotations.SerializedName;
  * }
  * </pre>
  *
- * @see <a href="https://docs.nextcloud.com/server/latest/developer_manual//client_apis/OCS/ocs-api-overview.html#capabilities-api">Capabilities API</a>
+ * @see <a href="https://docs.nextcloud.com/server/latest/developer_manual/client_apis/OCS/ocs-api-overview.html#capabilities-api">Capabilities API</a>
  */
 @SuppressWarnings("unused, SpellCheckingInspection")
 public class OcsCapabilitiesResponse {

--- a/lib/src/main/java/com/nextcloud/android/sso/model/ocs/OcsCapabilitiesResponse.java
+++ b/lib/src/main/java/com/nextcloud/android/sso/model/ocs/OcsCapabilitiesResponse.java
@@ -40,7 +40,7 @@ public class OcsCapabilitiesResponse {
             @SerializedName("color-text")
             public String colorText;
             @SerializedName("color-element")
-            public String cnextcloudapiolorElement;
+            public String colorElement;
             @SerializedName("color-element-bright")
             public String colorElementBright;
             @SerializedName("color-element-dark")
@@ -51,7 +51,8 @@ public class OcsCapabilitiesResponse {
             public boolean backgroundPlain;
             @SerializedName("background-default")
             public boolean backgroundDefault;
-            public String logoheader;
+            @SerializedName("logoheader")
+            public String logoHeader;
             public String favicon;
         }
     }

--- a/lib/src/main/java/com/nextcloud/android/sso/model/ocs/OcsResponse.java
+++ b/lib/src/main/java/com/nextcloud/android/sso/model/ocs/OcsResponse.java
@@ -1,0 +1,34 @@
+package com.nextcloud.android.sso.model.ocs;
+
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * <p>A generic wrapper for <a href="https://www.open-collaboration-services.org/">OpenCollaborationServices</a> responses.</p>
+ * <p>This is a convenience class for API endpoints located at <code>/ocs/…</code> which all have an identical wrapping structure.<br>
+ * It is usually <strong>not</strong> used in APIs of 3rd party server apps like <a href="https://deck.readthedocs.io/en/latest/API/">Deck</a> or <a href="https://github.com/nextcloud/notes/blob/master/docs/api/README.md">Notes</a></p>
+ * <p>Example usage with Retrofit:</p>
+ * <pre>
+ * {@code
+ * @GET("/ocs/v2.php/cloud/capabilities?format=json")
+ * Call<OcsResponse<OcsCapabilitiesResponse>> getCapabilities();
+ * }
+ * </pre>
+ *
+ * @param <T> defines the payload type of this {@link OcsResponse}.
+ */
+@SuppressWarnings("unused, SpellCheckingInspection")
+public class OcsResponse<T> {
+    public OcsWrapper<T> ocs;
+
+    public static class OcsWrapper<T> {
+        public OcsMeta meta;
+        public T data;
+
+        public static class OcsMeta {
+            public String status;
+            @SerializedName("statuscode")
+            public int statusCode;
+            public String message;
+        }
+    }
+}

--- a/lib/src/main/java/com/nextcloud/android/sso/model/ocs/OcsUser.java
+++ b/lib/src/main/java/com/nextcloud/android/sso/model/ocs/OcsUser.java
@@ -1,0 +1,40 @@
+package com.nextcloud.android.sso.model.ocs;
+
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * <p>This is a basic implementation for the <code>users</code> endpoint which maps often required properties.<br>
+ * You can use it directly in combination with {@link OcsResponse} or extend it.</p>
+ * <p>Example usage with Retrofit:</p>
+ * <pre>
+ * {@code
+ * @GET("/ocs/v2.php/cloud/users/{search}?format=json")
+ * Call<OcsResponse<OcsUser>> getUser(@Path("search") String userId);
+ * }
+ * </pre>
+ * @see <a href="https://docs.nextcloud.com/server/latest/developer_manual/client_apis/OCS/ocs-api-overview.html#user-metadata">User API</a>
+ */
+@SuppressWarnings("SpellCheckingInspection")
+public class OcsUser {
+    public boolean enabled;
+    @SerializedName("id")
+    public String userId;
+    public long lastLogin;
+    public OcsQuota quota;
+    public String email;
+    @SerializedName("displayname")
+    public String displayName;
+    public String phone;
+    public String address;
+    public String website;
+    public String twitter;
+    public String[] groups;
+    public String language;
+    public String locale;
+
+    public static class OcsQuota {
+        public long free;
+        public long used;
+        public long total;
+    }
+}

--- a/sample/src/main/java/com/nextcloud/android/sso/sample/MainActivity.java
+++ b/sample/src/main/java/com/nextcloud/android/sso/sample/MainActivity.java
@@ -73,7 +73,7 @@ public class MainActivity extends AppCompatActivity {
                         /* Show result on the UI thread */
                         runOnUiThread(() -> ((TextView) findViewById(R.id.result)).setText(
                                 getString(R.string.account_info,
-                                        user.displayname,
+                                        user.displayName,
                                         serverInfo.capabilities.theming.name,
                                         serverInfo.version.semanticVersion))
                         );

--- a/sample/src/main/java/com/nextcloud/android/sso/sample/OcsAPI.java
+++ b/sample/src/main/java/com/nextcloud/android/sso/sample/OcsAPI.java
@@ -2,6 +2,9 @@ package com.nextcloud.android.sso.sample;
 
 
 import com.google.gson.annotations.SerializedName;
+import com.nextcloud.android.sso.model.ocs.OcsCapabilitiesResponse;
+import com.nextcloud.android.sso.model.ocs.OcsResponse;
+import com.nextcloud.android.sso.model.ocs.OcsUser;
 
 import retrofit2.Call;
 import retrofit2.http.GET;
@@ -10,67 +13,51 @@ import retrofit2.http.Path;
 /**
  * @see <a href="https://deck.readthedocs.io/en/latest/API-Nextcloud/">Nextcloud REST API</a>
  */
-@SuppressWarnings("unused, SpellCheckingInspection")
 public interface OcsAPI {
-
-    @GET("capabilities?format=json")
-    Call<OcsResponse<OcsServerInfo>> getServerInfo();
 
     @GET("users/{search}?format=json")
     Call<OcsResponse<OcsUser>> getUser(@Path("search") String userId);
 
-    /**
-     * <p>A generic wrapper for <a href="https://www.open-collaboration-services.org/">OpenCollaborationServices</a> calls.</p>
-     * <p>This is a convenience class for API endpoints located at <code>/ocs/…</code> which have an identical wrapping structure. It is usually not used for APIs of 3rd party server apps like <a href="https://deck.readthedocs.io/en/latest/API/">Deck</a> or <a href="https://github.com/nextcloud/notes/blob/master/docs/api/README.md">Notes</a></p>
-     *
-     * @see <a href="https://github.com/nextcloud/Android-SingleSignOn/issues/401">Request to ship this class by default</a>
-     *
-     * @param <T> defines the payload type of this {@link OcsResponse}.
-     */
-    class OcsResponse<T> {
-        public OcsWrapper<T> ocs;
-
-        public static class OcsWrapper<T> {
-            public OcsMeta meta;
-            public T data;
-        }
-
-        public static class OcsMeta {
-            public String status;
-            public int statuscode;
-            public String message;
-        }
-    }
+    @GET("capabilities?format=json")
+    Call<CustomResponse> getServerInfo();
 
     /**
-     * <a href="https://github.com/google/gson"><code>Gson</code></a> maps the payload of the request to this data structure.
-     * Attributes must be public or must have public getter & setter.
+     * <p>This is for demonstration purposes only. In your apps, you will usually want to use
+     * {@link OcsResponse} for requests which target <code>/ocs/…</code> in combination with
+     * {@link OcsCapabilitiesResponse} or a subclass.</p>
      *
-     * Extend your object mappers by the attributes you are actually using.
+     * <p><a href="https://github.com/google/gson"><code>Gson</code></a> maps the payload of the request to this data structure.<br>
+     * Attributes must be public or must have public getter & setter.</p>
+     *
+     * <p>Extend your object mappers by the attributes you are actually using.</p>
      */
-    class OcsServerInfo {
-        public OcsVersion version;
-        public OcsCapabilities capabilities;
+    class CustomResponse {
+        public OcsNode ocs;
 
-        static class OcsVersion {
-            /**
-             * You can map the <code>JSON</code> attributes to other variable names using {@link SerializedName}.
-             * See <a href="https://github.com/google/gson"><code>Gson</code></a>- and <a href="https://square.github.io/retrofit/"><code>Retrofit</code></a>-Documentation for all possibilities.
-             */
-            @SerializedName("string")
-            public String semanticVersion;
-        }
+        static class OcsNode {
+            public DataNode data;
 
-        static class OcsCapabilities {
-            public Theming theming;
+            static class DataNode {
+                public VersionNode version;
+                public CapabilitiesNode capabilities;
 
-            static class Theming {
-                public String name;
+                static class VersionNode {
+                    /**
+                     * You can map the <code>JSON</code> attributes to other variable names using {@link SerializedName}.
+                     * See <a href="https://github.com/google/gson"><code>Gson</code></a>- and <a href="https://square.github.io/retrofit/"><code>Retrofit</code></a>-Documentation for all possibilities.
+                     */
+                    @SerializedName("string")
+                    public String semanticVersion;
+                }
+
+                static class CapabilitiesNode {
+                    public ThemingNode theming;
+
+                    static class ThemingNode {
+                        public String name;
+                    }
+                }
             }
         }
-    }
-
-    class OcsUser {
-        public String displayname;
     }
 }


### PR DESCRIPTION
- Add convenience classes
  - Generic wrapper for `OCS` calls: `OcsResponse`
  - Basic implementation for `OcsUser`
  - Basic implementation for `OcsCapabilitiesResponse`
- Adjust sample app to use `OcsResponse<OcsUser>` for one call and a custom mapper for the `capabilities` endpoint, to show both scenarios (The latter is useful for 3rd party APIs like `Deck`, `Notes` or `News`)
- Add JavaDoc to `NextcloudAPI#onStop()`

Signed-off-by: Stefan Niedermann <info@niedermann.it>