### PR TITLE
#113 Remove deprecated v1 system

### DIFF
--- a/lib/src/main/aidl/com/nextcloud/android/sso/aidl/IInputStreamService.aidl
+++ b/lib/src/main/aidl/com/nextcloud/android/sso/aidl/IInputStreamService.aidl
@@ -18,11 +18,7 @@
 package com.nextcloud.android.sso.aidl;
 
 interface IInputStreamService {
-    ParcelFileDescriptor performNextcloudRequestAndBodyStream(in ParcelFileDescriptor input, 
-                                                              in ParcelFileDescriptor requestBodyParcelFileDescriptor);
-    ParcelFileDescriptor performNextcloudRequest(in ParcelFileDescriptor input);
-    
-    ParcelFileDescriptor performNextcloudRequestAndBodyStreamV2(in ParcelFileDescriptor input, 
+    ParcelFileDescriptor performNextcloudRequestAndBodyStreamV2(in ParcelFileDescriptor input,
                                                                 in ParcelFileDescriptor requestBodyParcelFileDescriptor);
     ParcelFileDescriptor performNextcloudRequestV2(in ParcelFileDescriptor input);
 }

--- a/lib/src/main/aidl/com/nextcloud/android/sso/aidl/IInputStreamService.aidl
+++ b/lib/src/main/aidl/com/nextcloud/android/sso/aidl/IInputStreamService.aidl
@@ -18,6 +18,10 @@
 package com.nextcloud.android.sso.aidl;
 
 interface IInputStreamService {
+    ParcelFileDescriptor performNextcloudRequestAndBodyStream(in ParcelFileDescriptor input,
+                                                              in ParcelFileDescriptor requestBodyParcelFileDescriptor);
+    ParcelFileDescriptor performNextcloudRequest(in ParcelFileDescriptor input);
+
     ParcelFileDescriptor performNextcloudRequestAndBodyStreamV2(in ParcelFileDescriptor input,
                                                                 in ParcelFileDescriptor requestBodyParcelFileDescriptor);
     ParcelFileDescriptor performNextcloudRequestV2(in ParcelFileDescriptor input);

--- a/lib/src/main/aidl/com/nextcloud/android/sso/aidl/IInputStreamService.aidl
+++ b/lib/src/main/aidl/com/nextcloud/android/sso/aidl/IInputStreamService.aidl
@@ -18,11 +18,11 @@
 package com.nextcloud.android.sso.aidl;
 
 interface IInputStreamService {
-    ParcelFileDescriptor performNextcloudRequestAndBodyStream(in ParcelFileDescriptor input,
+    ParcelFileDescriptor performNextcloudRequestAndBodyStream(in ParcelFileDescriptor input, 
                                                               in ParcelFileDescriptor requestBodyParcelFileDescriptor);
     ParcelFileDescriptor performNextcloudRequest(in ParcelFileDescriptor input);
-
-    ParcelFileDescriptor performNextcloudRequestAndBodyStreamV2(in ParcelFileDescriptor input,
+    
+    ParcelFileDescriptor performNextcloudRequestAndBodyStreamV2(in ParcelFileDescriptor input, 
                                                                 in ParcelFileDescriptor requestBodyParcelFileDescriptor);
     ParcelFileDescriptor performNextcloudRequestV2(in ParcelFileDescriptor input);
 }

--- a/lib/src/main/java/com/nextcloud/android/sso/api/NetworkRequest.java
+++ b/lib/src/main/java/com/nextcloud/android/sso/api/NetworkRequest.java
@@ -19,7 +19,8 @@ public abstract class NetworkRequest {
     private SingleSignOnAccount mAccount;
     protected Context mContext;
     protected NextcloudAPI.ApiConnectedListener mCallback;
-    protected boolean mDestroyed = false; // Flag indicating if API is destroyed
+    /** Flag indicating whether API is destroyed */
+    protected boolean mDestroyed = false;
 
     protected NetworkRequest(@NonNull Context context, @NonNull SingleSignOnAccount account, @NonNull NextcloudAPI.ApiConnectedListener callback) {
         this.mContext = context;
@@ -33,8 +34,6 @@ public abstract class NetworkRequest {
             throw new IllegalStateException("API already destroyed! You cannot reuse a stopped API instance");
         }
     }
-
-    protected abstract InputStream performNetworkRequest(NextcloudRequest request, InputStream requestBodyInputStream) throws Exception;
 
     protected abstract Response performNetworkRequestV2(NextcloudRequest request, InputStream requestBodyInputStream) throws Exception;
 

--- a/lib/src/main/java/com/nextcloud/android/sso/api/NextcloudAPI.java
+++ b/lib/src/main/java/com/nextcloud/android/sso/api/NextcloudAPI.java
@@ -107,22 +107,6 @@ public class NextcloudAPI {
         networkRequest.stop();
     }
 
-    /**
-     * @deprecated Use {@link #performRequestObservableV2(Type, NextcloudRequest)}
-     * @see <a href="https://github.com/nextcloud/Android-SingleSignOn/issues/133">Issue #133</a>
-     */
-    @Deprecated
-    public <T> Observable<T> performRequestObservable(final Type type, final NextcloudRequest request) {
-        return Observable.fromPublisher( s -> {
-            try {
-                s.onNext(performRequest(type, request));
-                s.onComplete();
-            } catch (Exception e) {
-                s.onError(e);
-            }
-        });
-    }
-
     public <T> Observable<ParsedResponse<T>> performRequestObservableV2(final Type type, final NextcloudRequest request) {
         return Observable.fromPublisher( s -> {
             try {
@@ -133,16 +117,6 @@ public class NextcloudAPI {
                 s.onError(e);
             }
         });
-    }
-
-    /**
-     * @deprecated Use {@link #performRequestV2(Type, NextcloudRequest)}
-     * @see <a href="https://github.com/nextcloud/Android-SingleSignOn/issues/133">Issue #133</a>
-     */
-    @Deprecated
-    public <T> T performRequest(final @NonNull Type type, NextcloudRequest request) throws Exception {
-        Log.d(TAG, "performRequest() called with: type = [" + type + "], request = [" + request + "]");
-        return convertStreamToTargetEntity(performNetworkRequest(request), type);
     }
 
     public <T> T performRequestV2(final @NonNull Type type, NextcloudRequest request) throws Exception {
@@ -172,20 +146,6 @@ public class NextcloudAPI {
             }
         }
         return result;
-    }
-
-    /**
-     * The InputStreams needs to be closed after reading from it
-     *
-     * @param request {@link NextcloudRequest} request to be executed on server via Files app
-     * @return InputStream answer from server as InputStream
-     * @throws Exception or {@link SSOException}
-     * @see <a href="https://github.com/nextcloud/Android-SingleSignOn/issues/133">Issue #133</a>
-     * @deprecated Use {@link #performNetworkRequestV2(NextcloudRequest)}
-     */
-    @Deprecated
-    public InputStream performNetworkRequest(NextcloudRequest request) throws Exception {
-        return networkRequest.performNetworkRequest(request, request.getBodyAsStream());
     }
 
     /**

--- a/lib/src/main/java/com/nextcloud/android/sso/api/NextcloudRetrofitServiceMethod.java
+++ b/lib/src/main/java/com/nextcloud/android/sso/api/NextcloudRetrofitServiceMethod.java
@@ -184,7 +184,7 @@ public class NextcloudRetrofitServiceMethod<T> {
 
                 // Streaming
                 if(typeArgument == ResponseBody.class) {
-                    return (T) Observable.fromCallable(() -> Okhttp3Helper.getResponseBodyFromRequest(nextcloudAPI, request));
+                    return (T) Observable.fromCallable(() -> Okhttp3Helper.getResponseBodyFromRequestV2(nextcloudAPI, request));
                 } else if (typeArgument instanceof ParameterizedType) {
                     ParameterizedType innerType = (ParameterizedType) typeArgument;
                     Type innerOwnerType = innerType.getRawType();

--- a/lib/src/main/java/com/nextcloud/android/sso/helper/Okhttp3Helper.java
+++ b/lib/src/main/java/com/nextcloud/android/sso/helper/Okhttp3Helper.java
@@ -34,21 +34,6 @@ public final class Okhttp3Helper {
 
     private Okhttp3Helper() { }
 
-    /**
-     * @deprecated Use {@link #getResponseBodyFromRequestV2(NextcloudAPI, NextcloudRequest)}
-     * @see <a href="https://github.com/nextcloud/Android-SingleSignOn/issues/133">Issue #133</a>
-     */
-    @Deprecated
-    public static ResponseBody getResponseBodyFromRequest(NextcloudAPI nextcloudAPI, NextcloudRequest request) {
-        try {
-            final InputStream os = nextcloudAPI.performNetworkRequest(request);
-            return ResponseBody.create(null, 0, new BufferedSourceSSO(os));
-        } catch (Exception e) {
-            Log.e(TAG, "[getResponseBodyFromRequest] encountered a problem", e);
-        }
-        return ResponseBody.create(null, "");
-    }
-
     public static ResponseBody getResponseBodyFromRequestV2(NextcloudAPI nextcloudAPI, NextcloudRequest request) {
         try {
             final InputStream os = nextcloudAPI.performNetworkRequestV2(request).getBody();

--- a/lib/src/main/java/com/nextcloud/android/sso/helper/VersionCheckHelper.java
+++ b/lib/src/main/java/com/nextcloud/android/sso/helper/VersionCheckHelper.java
@@ -1,6 +1,5 @@
 package com.nextcloud.android.sso.helper;
 
-import android.app.Activity;
 import android.content.Context;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
@@ -19,11 +18,11 @@ public final class VersionCheckHelper {
 
     private VersionCheckHelper() { }
 
-    public static boolean verifyMinVersion(Activity activity, int minVersion) {
+    public static boolean verifyMinVersion(@NonNull Context context, int minVersion) {
         try {
-            final int verCode = getNextcloudFilesVersionCode(activity, true);
+            final int verCode = getNextcloudFilesVersionCode(context, true);
             if (verCode < minVersion) {
-                UiExceptionManager.showDialogForException(activity, new NextcloudFilesAppNotSupportedException());
+                UiExceptionManager.showDialogForException(context, new NextcloudFilesAppNotSupportedException());
                 return false;
             }
             return true;
@@ -32,7 +31,7 @@ public final class VersionCheckHelper {
 
             // Stable Files App is not installed at all. Therefore we need to run the test on the dev app
             try {
-                final int verCode = getNextcloudFilesVersionCode(activity, false);
+                final int verCode = getNextcloudFilesVersionCode(context, false);
                 // The dev app follows a different versioning schema.. therefore we can't do our normal checks
                 // However beta users are probably always up to date so we will just ignore it for now
                 Log.d(TAG, "Dev files app version is: " + verCode);
@@ -45,24 +44,20 @@ public final class VersionCheckHelper {
                 return true;
             } catch (PackageManager.NameNotFoundException ex) {
                 Log.e(TAG, "PackageManager.NameNotFoundException (dev files app not found): " + e.getMessage());
-                UiExceptionManager.showDialogForException(activity, new NextcloudFilesAppNotInstalledException());
+                UiExceptionManager.showDialogForException(context, new NextcloudFilesAppNotInstalledException());
             }
         }
         return false;
     }
 
     /**
-     * @deprecated use {@link #getNextcloudFilesVersionCode(Context, boolean)}
+     * @param context {@link Context}
+     * @param prod    if <code>true</code>, the version of {@link Constants#PACKAGE_NAME_PROD} is checked, otherwise {@link Constants#PACKAGE_NAME_DEV}.
      */
-    @Deprecated
-    public static int getNextcloudFilesVersionCode(@NonNull Context context) throws PackageManager.NameNotFoundException {
-        return getNextcloudFilesVersionCode(context, true);
-    }
-
     public static int getNextcloudFilesVersionCode(@NonNull Context context, boolean prod) throws PackageManager.NameNotFoundException {
         final PackageInfo pInfo = context.getPackageManager().getPackageInfo(prod ? Constants.PACKAGE_NAME_PROD : Constants.PACKAGE_NAME_DEV, 0);
         final int verCode = pInfo.versionCode;
-        Log.d("VersionCheckHelper", "Version Code: " + verCode);
+        Log.d(TAG, "Version Code: " + verCode);
         return verCode;
     }
 }


### PR DESCRIPTION
This removes all deprecated APIs from the SSO lib regarding the V1 system.

Hints for review:

- The old methods need to stay in `IInputStreamService.aidl` though, otherwise the sample app breaks. Ideas for a smooth migration are welcome, but i doubt that it is worth the efforts.
- `NextcloudRetrofitServiceMethod#invoke` always used `Okhttp3Helper.getResponseBodyFromRequest`, i moved this to `Okhttp3Helper.getResponseBodyFromRequestV2`
- `AidlNetworkRequest#performAidlNetworkRequest` used the following code part. The V2 pendant never had this. Shall we move this to the V2 or just ignore? (I also marked it as `TODO` in the code…)
```java
if (mDestroyed) {
    throw new IllegalStateException("Nextcloud API already destroyed. Please report this issue.");
}
```

- [ ] Unit tests
- [ ] Review

Signed-off-by: Stefan Niedermann <info@niedermann.it>