### PR TITLE
#409 Support .qa package id of the files app

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ For Android 11 and later [you need to add queries](https://github.com/nextcloud/
 ```xml
 <queries>
     <package android:name="com.nextcloud.client" />
+    <package android:name="com.nextcloud.android.qa" />
     <package android:name="com.nextcloud.android.beta" />
 </queries>
 ```

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -41,6 +41,7 @@ android {
         }
     }
     compileOptions {
+        coreLibraryDesugaringEnabled true
         sourceCompatibility JavaVersion.VERSION_11
         targetCompatibility JavaVersion.VERSION_11
     }
@@ -97,6 +98,8 @@ detekt {
 }
 
 dependencies {
+    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.1.5'
+
     implementation "androidx.appcompat:appcompat:1.3.1"
     implementation 'androidx.annotation:annotation:1.3.0'
     implementation 'androidx.core:core:1.7.0'

--- a/lib/src/main/AndroidManifest.xml
+++ b/lib/src/main/AndroidManifest.xml
@@ -7,6 +7,7 @@
 
     <queries>
         <package android:name="com.nextcloud.client" />
+        <package android:name="com.nextcloud.android.qa" />
         <package android:name="com.nextcloud.android.beta" />
     </queries>
 

--- a/lib/src/main/java/com/nextcloud/android/sso/Constants.java
+++ b/lib/src/main/java/com/nextcloud/android/sso/Constants.java
@@ -19,6 +19,8 @@
 
 package com.nextcloud.android.sso;
 
+import com.nextcloud.android.sso.model.FilesAppType;
+
 public class Constants {
 
     // Authenticator related constants
@@ -38,10 +40,24 @@ public class Constants {
     public static final String EXCEPTION_HTTP_REQUEST_FAILED = "CE_5";
     public static final String EXCEPTION_ACCOUNT_ACCESS_DECLINED = "CE_6";
 
-    // package related constans
-    public static final String PACKAGE_NAME_PROD = "com.nextcloud.client";
-    public static final String PACKAGE_NAME_DEV = "com.nextcloud.android.beta";
-    public static final String ACCOUNT_TYPE_PROD = "nextcloud";
-    public static final String ACCOUNT_TYPE_DEV = "nextcloud.beta";
-    
+    // package related constants
+    /** @deprecated Use {@link FilesAppType#packageId} */
+    @Deprecated
+    public static final String PACKAGE_NAME_PROD = FilesAppType.PROD.packageId;
+    /** @deprecated Use {@link FilesAppType#packageId} */
+    @Deprecated
+    public static final String PACKAGE_NAME_QA = FilesAppType.QA.packageId;
+    /** @deprecated Use {@link FilesAppType#packageId} */
+    @Deprecated
+    public static final String PACKAGE_NAME_DEV = FilesAppType.DEV.packageId;
+    /** @deprecated Use {@link FilesAppType#accountType} */
+    @Deprecated
+    public static final String ACCOUNT_TYPE_PROD = FilesAppType.PROD.accountType;
+    /** @deprecated Use {@link FilesAppType#accountType} */
+    @Deprecated
+    public static final String ACCOUNT_TYPE_QA = FilesAppType.QA.accountType;
+    /** @deprecated Use {@link FilesAppType#accountType} */
+    @Deprecated
+    public static final String ACCOUNT_TYPE_DEV = FilesAppType.DEV.accountType;
+
 }

--- a/lib/src/main/java/com/nextcloud/android/sso/Constants.java
+++ b/lib/src/main/java/com/nextcloud/android/sso/Constants.java
@@ -46,16 +46,10 @@ public class Constants {
     public static final String PACKAGE_NAME_PROD = FilesAppType.PROD.packageId;
     /** @deprecated Use {@link FilesAppType#packageId} */
     @Deprecated
-    public static final String PACKAGE_NAME_QA = FilesAppType.QA.packageId;
-    /** @deprecated Use {@link FilesAppType#packageId} */
-    @Deprecated
     public static final String PACKAGE_NAME_DEV = FilesAppType.DEV.packageId;
     /** @deprecated Use {@link FilesAppType#accountType} */
     @Deprecated
     public static final String ACCOUNT_TYPE_PROD = FilesAppType.PROD.accountType;
-    /** @deprecated Use {@link FilesAppType#accountType} */
-    @Deprecated
-    public static final String ACCOUNT_TYPE_QA = FilesAppType.QA.accountType;
     /** @deprecated Use {@link FilesAppType#accountType} */
     @Deprecated
     public static final String ACCOUNT_TYPE_DEV = FilesAppType.DEV.accountType;

--- a/lib/src/main/java/com/nextcloud/android/sso/api/AidlNetworkRequest.java
+++ b/lib/src/main/java/com/nextcloud/android/sso/api/AidlNetworkRequest.java
@@ -1,3 +1,22 @@
+/*
+ * Nextcloud SingleSignOn
+ *
+ * @author David Luhmer
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package com.nextcloud.android.sso.api;
 
 import static com.nextcloud.android.sso.aidl.ParcelFileDescriptorUtil.pipeFrom;

--- a/lib/src/main/java/com/nextcloud/android/sso/api/AidlNetworkRequest.java
+++ b/lib/src/main/java/com/nextcloud/android/sso/api/AidlNetworkRequest.java
@@ -19,10 +19,10 @@ import androidx.annotation.Nullable;
 
 import com.google.gson.Gson;
 import com.google.gson.internal.LinkedTreeMap;
-import com.nextcloud.android.sso.Constants;
 import com.nextcloud.android.sso.aidl.IInputStreamService;
 import com.nextcloud.android.sso.aidl.NextcloudRequest;
 import com.nextcloud.android.sso.exceptions.NextcloudApiNotRespondingException;
+import com.nextcloud.android.sso.model.FilesAppType;
 import com.nextcloud.android.sso.model.SingleSignOnAccount;
 
 import java.io.ByteArrayInputStream;
@@ -82,16 +82,14 @@ public class AidlNetworkRequest extends NetworkRequest {
         Log.d(TAG, "[connect] Binding to AccountManagerService for type [" + type + "]");
         super.connect(type);
 
-        final String componentName = Constants.ACCOUNT_TYPE_DEV.equals(type)
-            ? Constants.PACKAGE_NAME_DEV
-            : Constants.PACKAGE_NAME_PROD;
+        final String componentName = FilesAppType.findByAccountType(type).packageId;
 
-        Log.d(TAG, "[connect] Component name is: [" + componentName+ "]");
+        Log.d(TAG, "[connect] Component name is: [" + componentName + "]");
 
         try {
             final Intent intentService = new Intent();
             intentService.setComponent(new ComponentName(componentName,
-                                                         "com.owncloud.android.services.AccountManagerService"));
+                    "com.owncloud.android.services.AccountManagerService"));
             // https://developer.android.com/reference/android/content/Context#BIND_ABOVE_CLIENT
             if (!mContext.bindService(intentService, mConnection, Context.BIND_AUTO_CREATE | Context.BIND_ABOVE_CLIENT)) {
                 Log.d(TAG, "[connect] Binding to AccountManagerService returned false");
@@ -135,13 +133,13 @@ public class AidlNetworkRequest extends NetworkRequest {
     private void waitForApi() throws NextcloudApiNotRespondingException {
         synchronized (mBound) {
             // If service is not bound yet.. wait
-            if(!mBound.get()) {
-                Log.v(TAG, "[waitForApi] - api not ready yet.. waiting [" + Thread.currentThread().getName() +  "]");
+            if (!mBound.get()) {
+                Log.v(TAG, "[waitForApi] - api not ready yet.. waiting [" + Thread.currentThread().getName() + "]");
                 try {
                     mBound.wait(10000); // wait up to 10 seconds
 
                     // If api is still not bound after 10 seconds.. try reconnecting
-                    if(!mBound.get()) {
+                    if (!mBound.get()) {
                         throw new NextcloudApiNotRespondingException();
                     }
                 } catch (InterruptedException ex) {
@@ -154,7 +152,7 @@ public class AidlNetworkRequest extends NetworkRequest {
     /**
      * The InputStreams needs to be closed after reading from it
      *
-     * @param request {@link NextcloudRequest} request to be executed on server via Files app
+     * @param request                {@link NextcloudRequest} request to be executed on server via Files app
      * @param requestBodyInputStream inputstream to be sent to the server
      * @return InputStream answer from server as InputStream
      * @throws Exception or SSOException
@@ -184,12 +182,12 @@ public class AidlNetworkRequest extends NetworkRequest {
     /**
      * The InputStreams needs to be closed after reading from it
      *
-     * @deprecated Use {@link #performNetworkRequestV2(NextcloudRequest, InputStream)}
-     * @see <a href="https://github.com/nextcloud/Android-SingleSignOn/issues/133">Issue #133</a>
      * @param request                {@link NextcloudRequest} request to be executed on server via Files app
      * @param requestBodyInputStream inputstream to be sent to the server
      * @return InputStream answer from server as InputStream
      * @throws Exception or SSOException
+     * @see <a href="https://github.com/nextcloud/Android-SingleSignOn/issues/133">Issue #133</a>
+     * @deprecated Use {@link #performNetworkRequestV2(NextcloudRequest, InputStream)}
      */
     @Deprecated
     public InputStream performNetworkRequest(NextcloudRequest request, InputStream requestBodyInputStream) throws Exception {
@@ -220,11 +218,11 @@ public class AidlNetworkRequest extends NetworkRequest {
     /**
      * <strong>DO NOT CALL THIS METHOD DIRECTLY</strong> - use {@link #performNetworkRequest} instead
      *
-     * @deprecated Use {@link #performAidlNetworkRequestV2(NextcloudRequest, InputStream)}
-     * @see <a href="https://github.com/nextcloud/Android-SingleSignOn/issues/133">Issue #133</a>
      * @param request
      * @return
      * @throws IOException
+     * @see <a href="https://github.com/nextcloud/Android-SingleSignOn/issues/133">Issue #133</a>
+     * @deprecated Use {@link #performAidlNetworkRequestV2(NextcloudRequest, InputStream)}
      */
     @Deprecated
     private ParcelFileDescriptor performAidlNetworkRequest(@NonNull NextcloudRequest request,
@@ -232,11 +230,11 @@ public class AidlNetworkRequest extends NetworkRequest {
             throws IOException, RemoteException, NextcloudApiNotRespondingException {
 
         // Check if we are on the main thread
-        if(Looper.myLooper() == Looper.getMainLooper()) {
+        if (Looper.myLooper() == Looper.getMainLooper()) {
             throw new NetworkOnMainThreadException();
         }
 
-        if(mDestroyed) {
+        if (mDestroyed) {
             throw new IllegalStateException("Nextcloud API already destroyed. Please report this issue.");
         }
 
@@ -337,7 +335,7 @@ public class AidlNetworkRequest extends NetworkRequest {
             return value;
         }
 
-        private void writeObject(ObjectOutputStream oos) throws IOException{
+        private void writeObject(ObjectOutputStream oos) throws IOException {
             oos.writeObject(name);
             oos.writeObject(value);
         }

--- a/lib/src/main/java/com/nextcloud/android/sso/api/AidlNetworkRequest.java
+++ b/lib/src/main/java/com/nextcloud/android/sso/api/AidlNetworkRequest.java
@@ -152,7 +152,7 @@ public class AidlNetworkRequest extends NetworkRequest {
     /**
      * The InputStreams needs to be closed after reading from it
      *
-     * @param request                {@link NextcloudRequest} request to be executed on server via Files app
+     * @param request {@link NextcloudRequest} request to be executed on server via Files app
      * @param requestBodyInputStream inputstream to be sent to the server
      * @return InputStream answer from server as InputStream
      * @throws Exception or SSOException
@@ -182,12 +182,12 @@ public class AidlNetworkRequest extends NetworkRequest {
     /**
      * The InputStreams needs to be closed after reading from it
      *
+     * @deprecated Use {@link #performNetworkRequestV2(NextcloudRequest, InputStream)}
+     * @see <a href="https://github.com/nextcloud/Android-SingleSignOn/issues/133">Issue #133</a>
      * @param request                {@link NextcloudRequest} request to be executed on server via Files app
      * @param requestBodyInputStream inputstream to be sent to the server
      * @return InputStream answer from server as InputStream
      * @throws Exception or SSOException
-     * @see <a href="https://github.com/nextcloud/Android-SingleSignOn/issues/133">Issue #133</a>
-     * @deprecated Use {@link #performNetworkRequestV2(NextcloudRequest, InputStream)}
      */
     @Deprecated
     public InputStream performNetworkRequest(NextcloudRequest request, InputStream requestBodyInputStream) throws Exception {
@@ -218,11 +218,11 @@ public class AidlNetworkRequest extends NetworkRequest {
     /**
      * <strong>DO NOT CALL THIS METHOD DIRECTLY</strong> - use {@link #performNetworkRequest} instead
      *
+     * @deprecated Use {@link #performAidlNetworkRequestV2(NextcloudRequest, InputStream)}
+     * @see <a href="https://github.com/nextcloud/Android-SingleSignOn/issues/133">Issue #133</a>
      * @param request
      * @return
      * @throws IOException
-     * @see <a href="https://github.com/nextcloud/Android-SingleSignOn/issues/133">Issue #133</a>
-     * @deprecated Use {@link #performAidlNetworkRequestV2(NextcloudRequest, InputStream)}
      */
     @Deprecated
     private ParcelFileDescriptor performAidlNetworkRequest(@NonNull NextcloudRequest request,

--- a/lib/src/main/java/com/nextcloud/android/sso/helper/VersionCheckHelper.java
+++ b/lib/src/main/java/com/nextcloud/android/sso/helper/VersionCheckHelper.java
@@ -8,9 +8,9 @@ import android.util.Log;
 
 import androidx.annotation.NonNull;
 
-import com.nextcloud.android.sso.Constants;
 import com.nextcloud.android.sso.exceptions.NextcloudFilesAppNotInstalledException;
 import com.nextcloud.android.sso.exceptions.NextcloudFilesAppNotSupportedException;
+import com.nextcloud.android.sso.model.FilesAppType;
 import com.nextcloud.android.sso.ui.UiExceptionManager;
 
 public final class VersionCheckHelper {
@@ -19,11 +19,19 @@ public final class VersionCheckHelper {
 
     private VersionCheckHelper() { }
 
+    /**
+     * @deprecated Use {@link #verifyMinVersion(Context, int, FilesAppType)}
+     */
+    @Deprecated
     public static boolean verifyMinVersion(Activity activity, int minVersion) {
+        return verifyMinVersion(activity, minVersion, FilesAppType.PROD);
+    }
+
+    public static boolean verifyMinVersion(@NonNull Context context, int minVersion, @NonNull FilesAppType type) {
         try {
-            final int verCode = getNextcloudFilesVersionCode(activity, true);
+            final int verCode = getNextcloudFilesVersionCode(context, type);
             if (verCode < minVersion) {
-                UiExceptionManager.showDialogForException(activity, new NextcloudFilesAppNotSupportedException());
+                UiExceptionManager.showDialogForException(context, new NextcloudFilesAppNotSupportedException());
                 return false;
             }
             return true;
@@ -32,7 +40,7 @@ public final class VersionCheckHelper {
 
             // Stable Files App is not installed at all. Therefore we need to run the test on the dev app
             try {
-                final int verCode = getNextcloudFilesVersionCode(activity, false);
+                final int verCode = getNextcloudFilesVersionCode(context, type);
                 // The dev app follows a different versioning schema.. therefore we can't do our normal checks
                 // However beta users are probably always up to date so we will just ignore it for now
                 Log.d(TAG, "Dev files app version is: " + verCode);
@@ -45,22 +53,30 @@ public final class VersionCheckHelper {
                 return true;
             } catch (PackageManager.NameNotFoundException ex) {
                 Log.e(TAG, "PackageManager.NameNotFoundException (dev files app not found): " + e.getMessage());
-                UiExceptionManager.showDialogForException(activity, new NextcloudFilesAppNotInstalledException());
+                UiExceptionManager.showDialogForException(context, new NextcloudFilesAppNotInstalledException());
             }
         }
         return false;
     }
 
     /**
-     * @deprecated use {@link #getNextcloudFilesVersionCode(Context, boolean)}
+     * @deprecated use {@link #getNextcloudFilesVersionCode(Context, FilesAppType)}
      */
     @Deprecated
     public static int getNextcloudFilesVersionCode(@NonNull Context context) throws PackageManager.NameNotFoundException {
-        return getNextcloudFilesVersionCode(context, true);
+        return getNextcloudFilesVersionCode(context, FilesAppType.PROD);
     }
 
+    /**
+     * @deprecated use {@link #getNextcloudFilesVersionCode(Context, FilesAppType)}
+     */
+    @Deprecated
     public static int getNextcloudFilesVersionCode(@NonNull Context context, boolean prod) throws PackageManager.NameNotFoundException {
-        final PackageInfo pInfo = context.getPackageManager().getPackageInfo(prod ? Constants.PACKAGE_NAME_PROD : Constants.PACKAGE_NAME_DEV, 0);
+        return getNextcloudFilesVersionCode(context, prod ? FilesAppType.PROD : FilesAppType.DEV);
+    }
+
+    public static int getNextcloudFilesVersionCode(@NonNull Context context, @NonNull FilesAppType appType) throws PackageManager.NameNotFoundException {
+        final PackageInfo pInfo = context.getPackageManager().getPackageInfo(appType.packageId, 0);
         final int verCode = pInfo.versionCode;
         Log.d("VersionCheckHelper", "Version Code: " + verCode);
         return verCode;

--- a/lib/src/main/java/com/nextcloud/android/sso/helper/VersionCheckHelper.java
+++ b/lib/src/main/java/com/nextcloud/android/sso/helper/VersionCheckHelper.java
@@ -1,3 +1,22 @@
+/*
+ * Nextcloud SingleSignOn
+ *
+ * @author David Luhmer
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package com.nextcloud.android.sso.helper;
 
 import android.app.Activity;

--- a/lib/src/main/java/com/nextcloud/android/sso/model/FilesAppType.java
+++ b/lib/src/main/java/com/nextcloud/android/sso/model/FilesAppType.java
@@ -1,0 +1,33 @@
+package com.nextcloud.android.sso.model;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+public enum FilesAppType {
+
+    PROD("com.nextcloud.client", "nextcloud"),
+    QA("com.nextcloud.android.qa", "nextcloud.qa"),
+    DEV("com.nextcloud.android.beta", "nextcloud.beta");
+
+    public final String packageId;
+    public final String accountType;
+
+    FilesAppType(@NonNull String packageId, @NonNull String accountType) {
+        this.packageId = packageId;
+        this.accountType = accountType;
+    }
+
+    /**
+     * @return {@link #PROD}, {@link #QA} or {@link #DEV} depending on {@param accountType}.
+     * Uses {@link #PROD} as fallback.
+     */
+    @NonNull
+    public static FilesAppType findByAccountType(@Nullable String accountType) {
+        for (final var appType : FilesAppType.values()) {
+            if (appType.accountType.equalsIgnoreCase(accountType)) {
+                return appType;
+            }
+        }
+        return PROD;
+    }
+}

--- a/lib/src/main/java/com/nextcloud/android/sso/model/FilesAppType.java
+++ b/lib/src/main/java/com/nextcloud/android/sso/model/FilesAppType.java
@@ -1,3 +1,22 @@
+/*
+ * Nextcloud SingleSignOn
+ *
+ * @author Stefan Niedermann
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package com.nextcloud.android.sso.model;
 
 import androidx.annotation.NonNull;

--- a/lib/src/test/java/android/util/Log.java
+++ b/lib/src/test/java/android/util/Log.java
@@ -1,3 +1,22 @@
+/*
+ * Nextcloud SingleSignOn
+ *
+ * @author David Luhmer
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package android.util;
 
 // https://stackoverflow.com/questions/36787449/how-to-mock-method-e-in-log

--- a/sample/src/main/java/com/nextcloud/android/sso/sample/MainActivity.java
+++ b/sample/src/main/java/com/nextcloud/android/sso/sample/MainActivity.java
@@ -1,3 +1,22 @@
+/*
+ * Nextcloud SingleSignOn
+ *
+ * @author Stefan Niedermann
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package com.nextcloud.android.sso.sample;
 
 import android.content.Intent;

--- a/sample/src/main/java/com/nextcloud/android/sso/sample/OcsAPI.java
+++ b/sample/src/main/java/com/nextcloud/android/sso/sample/OcsAPI.java
@@ -1,5 +1,23 @@
-package com.nextcloud.android.sso.sample;
+/*
+ * Nextcloud SingleSignOn
+ *
+ * @author Stefan Niedermann
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 
+package com.nextcloud.android.sso.sample;
 
 import com.google.gson.annotations.SerializedName;
 import com.nextcloud.android.sso.model.ocs.OcsCapabilitiesResponse;


### PR DESCRIPTION
- Move loose Package ID and Account Type from `Constants` class to own `Enum` (`FilesAppType`)
- Mark old constants as `@Deprecated`, but keep them to maintain backward compatibility
- Clean up some methods which internally always used `prod` as target, even though we already supported `dev`. They will now be callable with an explicit `FilesAppType` (also full backward compatible)

Signed-off-by: Stefan Niedermann <info@niedermann.it>