### PR TITLE
enable aidl buildFeature

### DIFF
--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -34,6 +34,10 @@ android {
         consumerProguardFiles 'consumer-proguard-rules.pro'
     }
 
+    buildFeatures {
+        aidl true
+    }
+
     buildTypes {
         release {
             minifyEnabled false


### PR DESCRIPTION
build fails on latest Android Studio if the buildFeature is not explicitly enabled