### PR TITLE
Remove desugaring

### DIFF
--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -55,9 +55,8 @@ android {
     }
 
     compileOptions {
-        coreLibraryDesugaringEnabled true
-        sourceCompatibility JavaVersion.VERSION_17
-        targetCompatibility JavaVersion.VERSION_17
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
     }
 
     publishing {
@@ -114,7 +113,6 @@ detekt {
 }
 
 dependencies {
-    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.1.3'
 
     implementation "androidx.appcompat:appcompat:1.7.0"
     implementation 'androidx.annotation:annotation:1.9.1'

--- a/lib/src/main/java/com/nextcloud/android/sso/AccountImporter.java
+++ b/lib/src/main/java/com/nextcloud/android/sso/AccountImporter.java
@@ -45,6 +45,7 @@ import com.nextcloud.android.sso.exceptions.SSOException;
 import com.nextcloud.android.sso.exceptions.UnknownErrorException;
 import com.nextcloud.android.sso.model.SingleSignOnAccount;
 import com.nextcloud.android.sso.ui.UiExceptionManager;
+import com.nextcloud.android.sso.model.FilesAppType;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -119,9 +120,9 @@ public class AccountImporter {
     private static boolean appInstalledOrNot(Context context) {
         boolean returnValue = false;
         PackageManager pm = context.getPackageManager();
-        for (final var appType : FilesAppTypeRegistry.getInstance().getTypes()) {
+        for (final FilesAppType appType : FilesAppTypeRegistry.getInstance().getTypes()) {
             try {
-                pm.getPackageInfo(appType.packageId(), PackageManager.GET_ACTIVITIES);
+                pm.getPackageInfo(appType.packageId, PackageManager.GET_ACTIVITIES);
                 returnValue = true;
                 break;
             } catch (PackageManager.NameNotFoundException e) {
@@ -366,7 +367,7 @@ public class AccountImporter {
             throw new NextcloudFilesAppAccountPermissionNotGrantedException(context);
         }
 
-        String componentName = FilesAppTypeRegistry.getInstance().findByAccountType(account.type).packageId();
+        String componentName = FilesAppTypeRegistry.getInstance().findByAccountType(account.type).packageId;
 
         Intent authIntent = new Intent();
         authIntent.setComponent(new ComponentName(componentName,

--- a/lib/src/main/java/com/nextcloud/android/sso/FilesAppTypeRegistry.java
+++ b/lib/src/main/java/com/nextcloud/android/sso/FilesAppTypeRegistry.java
@@ -10,6 +10,7 @@ package com.nextcloud.android.sso;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import com.nextcloud.android.sso.helper.InternalStream;
 import com.nextcloud.android.sso.model.FilesAppType;
 
 import java.util.Collection;
@@ -30,7 +31,7 @@ public class FilesAppTypeRegistry {
     }
 
     public synchronized void init(@NonNull FilesAppType type) {
-        if (type.stage() != FilesAppType.Stage.PROD) {
+        if (type.stage != FilesAppType.Stage.PROD) {
             throw new IllegalArgumentException("If only one " + FilesAppType.class.getSimpleName() + " added, this must be " + FilesAppType.Stage.PROD.name() + "!");
         }
 
@@ -39,7 +40,7 @@ public class FilesAppTypeRegistry {
     }
 
     public synchronized void init(@NonNull Collection<FilesAppType> types) {
-        if (!types.stream().anyMatch(t -> t.stage() == FilesAppType.Stage.PROD)) {
+        if (!new InternalStream<>(types).anyMatch(t -> t.stage == FilesAppType.Stage.PROD)) {
             throw new IllegalArgumentException("At least one provided " + FilesAppType.class.getSimpleName() + " must be " + FilesAppType.Stage.PROD.name() + "!");
         }
 
@@ -54,9 +55,8 @@ public class FilesAppTypeRegistry {
 
     @NonNull
     public String[] getAccountTypes() {
-        return types
-            .stream()
-            .map(FilesAppType::accountType)
+        return new InternalStream<>(types)
+            .map(t -> t.accountType)
             .toArray(String[]::new);
     }
 
@@ -68,15 +68,14 @@ public class FilesAppTypeRegistry {
      */
     @NonNull
     public FilesAppType findByAccountType(@Nullable String accountType) {
-        for (final var type : types) {
-            if (type.accountType().equalsIgnoreCase(accountType)) {
+        for (final FilesAppType type : types) {
+            if (type.accountType.equalsIgnoreCase(accountType)) {
                 return type;
             }
         }
 
-        return types
-            .stream()
-            .filter(t -> t.stage() == FilesAppType.Stage.PROD)
+        return new InternalStream<>(types)
+            .filter(t -> t.stage == FilesAppType.Stage.PROD)
             .findFirst()
             .get();
     }

--- a/lib/src/main/java/com/nextcloud/android/sso/api/AidlNetworkRequest.java
+++ b/lib/src/main/java/com/nextcloud/android/sso/api/AidlNetworkRequest.java
@@ -91,7 +91,7 @@ public class AidlNetworkRequest extends NetworkRequest {
         Log.d(TAG, "[connect] Binding to AccountManagerService for type [" + type + "]");
         super.connect(type);
 
-        final String componentName = FilesAppTypeRegistry.getInstance().findByAccountType(type).packageId();
+        final String componentName = FilesAppTypeRegistry.getInstance().findByAccountType(type).packageId;
 
         Log.d(TAG, "[connect] Component name is: [" + componentName + "]");
 
@@ -171,14 +171,14 @@ public class AidlNetworkRequest extends NetworkRequest {
         final ParcelFileDescriptor output = performAidlNetworkRequestV2(request, requestBodyInputStream);
         final InputStream os = new ParcelFileDescriptor.AutoCloseInputStream(output);
         try {
-            final var response = deserializeObjectV2(os);
+            final ExceptionResponse response = deserializeObjectV2(os);
 
             // Handle Remote Exceptions
-            if (response.exception() != null) {
-                if (response.exception().getMessage() != null) {
-                    throw parseNextcloudCustomException(mContext, response.exception());
+            if (response.exception != null) {
+                if (response.exception.getMessage() != null) {
+                    throw parseNextcloudCustomException(mContext, response.exception);
                 }
-                throw response.exception();
+                throw response.exception;
             }
             // os stream needs to stay open to be able to read response
             return new Response(os, response.headers);
@@ -275,9 +275,14 @@ public class AidlNetworkRequest extends NetworkRequest {
         }
     }
 
-    private record ExceptionResponse(
-        @NonNull ArrayList<PlainHeader> headers,
-        @Nullable Exception exception
-    ) {
+
+    private class ExceptionResponse {
+        @NonNull public final ArrayList<PlainHeader> headers;
+        @Nullable public final Exception exception;
+
+        private ExceptionResponse(@NonNull ArrayList<PlainHeader> headers, @Nullable Exception exception) {
+            this.headers = headers;
+            this.exception = exception;
+        }
     }
 }

--- a/lib/src/main/java/com/nextcloud/android/sso/exceptions/SSOException.java
+++ b/lib/src/main/java/com/nextcloud/android/sso/exceptions/SSOException.java
@@ -16,7 +16,6 @@ import androidx.annotation.Nullable;
 import androidx.annotation.StringRes;
 
 import com.nextcloud.android.sso.Constants;
-import com.nextcloud.android.sso.helper.InternalOption;
 
 public class SSOException extends Exception {
 
@@ -65,16 +64,16 @@ public class SSOException extends Exception {
         this.actionIntent = actionIntent;
     }
 
-    public InternalOption<Integer> getTitleRes() {
-        return new InternalOption<>(titleRes);
+    public @Nullable Integer getTitleRes() {
+        return titleRes;
     }
 
-    public InternalOption<Integer> getPrimaryActionTextRes() {
-        return new InternalOption<>(actionTextRes);
+    public @Nullable Integer getPrimaryActionTextRes() {
+        return actionTextRes;
     }
 
-    public InternalOption<Intent> getPrimaryAction() {
-        return new InternalOption<>(actionIntent);
+    public @Nullable Intent getPrimaryAction() {
+        return actionIntent;
     }
 
     public static SSOException parseNextcloudCustomException(@NonNull Context context, @Nullable Exception exception) throws NextcloudHttpRequestFailedException {

--- a/lib/src/main/java/com/nextcloud/android/sso/helper/FilesAppNotInstalledHelperUtil.java
+++ b/lib/src/main/java/com/nextcloud/android/sso/helper/FilesAppNotInstalledHelperUtil.java
@@ -22,14 +22,14 @@ public final class FilesAppNotInstalledHelperUtil {
 
     public static void requestInstallNextcloudFilesApp(@NonNull Context context) {
         // Nextcloud app not installed
-        final var installIntent = new Intent(Intent.ACTION_VIEW, Uri.parse(context.getString(R.string.url_files_app_marketplace)));
+        final Intent installIntent = new Intent(Intent.ACTION_VIEW, Uri.parse(context.getString(R.string.url_files_app_marketplace)));
 
         // launch market(s)
         if (installIntent.resolveActivity(context.getPackageManager()) != null) {
             context.startActivity(installIntent);
         } else {
             // no F-Droid market app or Play store installed → launch browser for f-droid url
-            final var downloadIntent = new Intent(Intent.ACTION_VIEW, Uri.parse(context.getString(R.string.url_files_app_fdroid)));
+            final Intent downloadIntent = new Intent(Intent.ACTION_VIEW, Uri.parse(context.getString(R.string.url_files_app_fdroid)));
             context.startActivity(downloadIntent);
         }
     }

--- a/lib/src/main/java/com/nextcloud/android/sso/helper/InternalOption.java
+++ b/lib/src/main/java/com/nextcloud/android/sso/helper/InternalOption.java
@@ -4,6 +4,8 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.core.util.Function;
 
+@androidx.annotation.Discouraged(message = "Do not publish this class.\n" +
+        "This must not be returned or a parameter of a published function.")
 public class InternalOption<T> {
     @Nullable private final T val;
 

--- a/lib/src/main/java/com/nextcloud/android/sso/helper/InternalOption.java
+++ b/lib/src/main/java/com/nextcloud/android/sso/helper/InternalOption.java
@@ -1,0 +1,45 @@
+package com.nextcloud.android.sso.helper;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.core.util.Function;
+
+public class InternalOption<T> {
+    @Nullable private final T val;
+
+     public InternalOption(@Nullable T val) {
+         this.val = val;
+     }
+     
+     public T orElse(@NonNull T fallback) {
+         if (val == null) {
+             return fallback;
+         } else {
+             return val;
+         }
+     }
+
+     public T get() {
+         if (val == null) {
+             throw new java.util.NoSuchElementException();
+         } else {
+             return val;
+         }
+     }
+
+    // Use androidx function
+     public <A> InternalOption<A> map(Function<T, A> mapper) {
+         return new InternalOption<>(mapper.apply(val));
+     }
+
+    // Use androidx function
+    public <B> void ifPresent(Function<T, B> mapper) {
+         if (val != null) {
+             mapper.apply(val);
+         }
+    }
+
+    public boolean isPresent() {
+        return val != null;
+    }
+}

--- a/lib/src/main/java/com/nextcloud/android/sso/helper/InternalStream.java
+++ b/lib/src/main/java/com/nextcloud/android/sso/helper/InternalStream.java
@@ -8,6 +8,8 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.Map;
 
+@androidx.annotation.Discouraged(message = "Do not publish this class.\n" +
+    "This must not be returned or a parameter of a published function.")
 public class InternalStream<T> {
     private final Collection<T> collection;
 

--- a/lib/src/main/java/com/nextcloud/android/sso/helper/InternalStream.java
+++ b/lib/src/main/java/com/nextcloud/android/sso/helper/InternalStream.java
@@ -1,0 +1,66 @@
+package com.nextcloud.android.sso.helper;
+
+import androidx.core.util.Function;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.Map;
+
+public class InternalStream<T> {
+    private final Collection<T> collection;
+
+    public InternalStream(Collection<T> list) {
+        this.collection = list;
+    }
+
+    // Use androidx function
+    public <A> InternalStream<A> map(Function<T, A> mapper) {
+        Collection<A> out = new LinkedList<>();
+        for (T t : collection) {
+            out.add(mapper.apply(t));
+        }
+        return new InternalStream<>(out);
+    }
+
+    // Use androidx function
+    public <A, B> Map<A, B> collectMap(Function<T, A> keyCollector, Function<T, B> valueCollector) {
+        Map<A, B> out = new HashMap<>();
+        for (T t : collection) {
+            out.put(keyCollector.apply(t), valueCollector.apply(t));
+        }
+        return out;
+    }
+
+    // Use androidx function
+    public InternalStream<T> filter(Function<T, Boolean> filter) {
+        for (T t : collection) {
+            if (!filter.apply(t)) {
+                collection.remove(t);
+            }
+        }
+        return this;
+    }
+
+    public Boolean anyMatch(Function<T, Boolean> filter) {
+        return this.filter(filter).findFirst().isPresent();
+    }
+
+    public InternalOption<T> findFirst() {
+        Iterator<T> iterator = collection.iterator();
+        if (iterator.hasNext()) {
+            return new InternalOption<>(iterator.next());
+        }
+        return new InternalOption<>(null);
+    }
+
+    public T[] toArray(Function<Integer, T[]> generator) {
+        T[] out = generator.apply(collection.size());
+        int i = 0;
+        for (T t : collection) {
+            out[i++] = t;
+        }
+        return out;
+    }
+}

--- a/lib/src/main/java/com/nextcloud/android/sso/helper/VersionCheckHelper.java
+++ b/lib/src/main/java/com/nextcloud/android/sso/helper/VersionCheckHelper.java
@@ -9,6 +9,7 @@
 package com.nextcloud.android.sso.helper;
 
 import android.content.Context;
+import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.util.Log;
 
@@ -19,8 +20,6 @@ import com.nextcloud.android.sso.exceptions.NextcloudFilesAppNotInstalledExcepti
 import com.nextcloud.android.sso.exceptions.NextcloudFilesAppNotSupportedException;
 import com.nextcloud.android.sso.model.FilesAppType;
 import com.nextcloud.android.sso.ui.UiExceptionManager;
-
-import java.util.Optional;
 
 public final class VersionCheckHelper {
 
@@ -41,11 +40,10 @@ public final class VersionCheckHelper {
 
             // Stable Files App is not installed at all. Therefore we need to run the test on the dev app
             try {
-                Optional<FilesAppType> dev = FilesAppTypeRegistry
+                InternalOption<FilesAppType> dev = new InternalStream<>(FilesAppTypeRegistry
                     .getInstance()
-                    .getTypes()
-                    .stream()
-                    .filter(t -> t.stage() == FilesAppType.Stage.DEV)
+                    .getTypes())
+                    .filter(t -> t.stage == FilesAppType.Stage.DEV)
                     .findFirst();
                 if (dev.isPresent()) {
                     final int verCode = getNextcloudFilesVersionCode(context, dev.get());
@@ -66,7 +64,7 @@ public final class VersionCheckHelper {
     }
 
     public static int getNextcloudFilesVersionCode(@NonNull Context context, @NonNull FilesAppType appType) throws PackageManager.NameNotFoundException {
-        final var packageInfo = context.getPackageManager().getPackageInfo(appType.packageId(), 0);
+        final PackageInfo packageInfo = context.getPackageManager().getPackageInfo(appType.packageId, 0);
         final int verCode = packageInfo.versionCode;
         Log.d("VersionCheckHelper", "Version Code: " + verCode);
         return verCode;

--- a/lib/src/main/java/com/nextcloud/android/sso/model/FilesAppType.java
+++ b/lib/src/main/java/com/nextcloud/android/sso/model/FilesAppType.java
@@ -9,12 +9,19 @@ package com.nextcloud.android.sso.model;
 
 import androidx.annotation.NonNull;
 
-public record FilesAppType(@NonNull String packageId,
-                           @NonNull String accountType,
-                           @NonNull Stage stage) {
+public class FilesAppType {
+    @NonNull public final String packageId;
+    @NonNull public final String accountType;
+    @NonNull public final Stage stage;
 
     public FilesAppType(@NonNull String accountType, @NonNull String packageId) {
         this(packageId, accountType, Stage.PROD);
+    }
+
+    public FilesAppType(@NonNull String packageId, @NonNull String accountType, @NonNull Stage stage) {
+        this.packageId = packageId;
+        this.accountType = accountType;
+        this.stage = stage;
     }
 
     public enum Stage {

--- a/lib/src/main/java/com/nextcloud/android/sso/model/ocs/OcsCapabilitiesResponse.java
+++ b/lib/src/main/java/com/nextcloud/android/sso/model/ocs/OcsCapabilitiesResponse.java
@@ -23,46 +23,79 @@ import com.google.gson.annotations.SerializedName;
  * @see <a href="https://docs.nextcloud.com/server/latest/developer_manual/client_apis/OCS/ocs-api-overview.html#capabilities-api">Capabilities API</a>
  */
 @SuppressWarnings("unused, SpellCheckingInspection")
-public record OcsCapabilitiesResponse(
-    OcsVersion version,
-    OcsCapabilities capabilities
-) {
-    public record OcsVersion(
-        int major,
-        int minor,
-        int macro,
-        String string,
-        String edition,
-        boolean extendedSupport
-    ) {
+public class OcsCapabilitiesResponse {
+    public final OcsVersion version;
+    public final OcsCapabilities capabilities;
+
+    public OcsCapabilitiesResponse(OcsVersion version, OcsCapabilities capabilities) {
+        this.version = version;
+        this.capabilities = capabilities;
     }
 
-    public record OcsCapabilities(
-        OcsTheming theming
-    ) {
-        public record OcsTheming(
-            String name,
-            String url,
-            String slogan,
-            String color,
+    public class OcsVersion {
+        public final int major;
+        public final int minor;
+        public final int macro;
+        public final String string;
+        public final String edition;
+        public final boolean extendedSupport;
+
+        public OcsVersion(int major, int minor, int macro, String string, String edition, boolean extendedSupport) {
+            this.major = major;
+            this.minor = minor;
+            this.macro = macro;
+            this.string = string;
+            this.edition = edition;
+            this.extendedSupport = extendedSupport;
+        }
+    }
+
+    public class OcsCapabilities {
+        public final OcsTheming theming;
+
+        public OcsCapabilities(OcsTheming theming) {
+            this.theming = theming;
+        }
+
+        public class OcsTheming {
+            public final String name;
+            public final String url;
+            public final String slogan;
+            public final String color;
             @SerializedName("color-text")
-            String colorText,
+            public final String colorText;
             @SerializedName("color-element")
-            String colorElement,
+            public final String colorElement;
             @SerializedName("color-element-bright")
-            String colorElementBright,
+            public final String colorElementBright;
             @SerializedName("color-element-dark")
-            String colorElementDark,
-            String logo,
-            String background,
+            public final String colorElementDark;
+            public final String logo;
+            public final String background;
             @SerializedName("background-plain")
-            boolean backgroundPlain,
+            public final boolean backgroundPlain;
             @SerializedName("background-default")
-            boolean backgroundDefault,
+            public final boolean backgroundDefault;
             @SerializedName("logoheader")
-            String logoHeader,
-            String favicon
-        ) {
+            public final String logoHeader;
+            public final String favicon;
+
+            public OcsTheming(String name, String url, String slogan, String color, String colorText, String colorElement, String colorElementBright, String colorElementDark, String logo, String background, boolean backgroundPlain, boolean backgroundDefault, String logoHeader, String favicon) {
+                this.name = name;
+                this.url = url;
+                this.slogan = slogan;
+                this.color = color;
+                this.colorText = colorText;
+                this.colorElement = colorElement;
+                this.colorElementBright = colorElementBright;
+                this.colorElementDark = colorElementDark;
+                this.logo = logo;
+                this.background = background;
+                this.backgroundPlain = backgroundPlain;
+                this.backgroundDefault = backgroundDefault;
+                this.logoHeader = logoHeader;
+                this.favicon = favicon;
+            }
         }
     }
 }

--- a/lib/src/main/java/com/nextcloud/android/sso/model/ocs/OcsResponse.java
+++ b/lib/src/main/java/com/nextcloud/android/sso/model/ocs/OcsResponse.java
@@ -24,19 +24,33 @@ import com.google.gson.annotations.SerializedName;
  * @param <T> defines the payload type of this {@link OcsResponse}.
  */
 @SuppressWarnings("unused, SpellCheckingInspection")
-public record OcsResponse<T>(
-    OcsWrapper<T> ocs
-) {
-    public record OcsWrapper<T>(
-        OcsMeta meta,
-        T data
-    ) {
-        public record OcsMeta(
-            String status,
+public class OcsResponse<T> {
+    public final OcsWrapper<T> ocs;
+
+    public OcsResponse(OcsWrapper<T> ocs) {
+        this.ocs = ocs;
+    }
+
+    public class OcsWrapper<T> {
+        public final OcsMeta meta;
+        public final T data;
+
+        public OcsWrapper(OcsMeta meta, T data) {
+            this.meta = meta;
+            this.data = data;
+        }
+
+        public class OcsMeta {
+            public final String status;
             @SerializedName("statuscode")
-            int statusCode,
-            String message
-        ) {
+            public final int statusCode;
+            public final String message;
+
+            public OcsMeta(String status, int statusCode, String message) {
+                this.status = status;
+                this.statusCode = statusCode;
+                this.message = message;
+            }
         }
     }
 }

--- a/lib/src/main/java/com/nextcloud/android/sso/model/ocs/OcsUser.java
+++ b/lib/src/main/java/com/nextcloud/android/sso/model/ocs/OcsUser.java
@@ -22,27 +22,48 @@ import com.google.gson.annotations.SerializedName;
  * @see <a href="https://docs.nextcloud.com/server/latest/developer_manual/client_apis/OCS/ocs-api-overview.html#user-metadata">User API</a>
  */
 @SuppressWarnings("SpellCheckingInspection")
-public record OcsUser(
-    boolean enabled,
+public class OcsUser {
+    public final boolean enabled;
     @SerializedName("id")
-    String userId,
-    long lastLogin,
-    OcsQuota quota,
-    String email,
+    public final String userId;
+    public final long lastLogin;
+    public final OcsQuota quota;
+    public final String email;
     @SerializedName("displayname")
-    String displayName,
-    String phone,
-    String address,
-    String website,
-    String twitter,
-    String[] groups,
-    String language,
-    String locale
-) {
-    public record OcsQuota(
-        long free,
-        long used,
-        long total
-    ) {
+    public final String displayName;
+    public final String phone;
+    public final String address;
+    public final String website;
+    public final String twitter;
+    public final String[] groups;
+    public final String language;
+    public final String locale;
+
+    public OcsUser(boolean enabled, String userId, long lastLogin, OcsQuota quota, String email, String displayName, String phone, String address, String website, String twitter, String[] groups, String language, String locale) {
+        this.enabled = enabled;
+        this.userId = userId;
+        this.lastLogin = lastLogin;
+        this.quota = quota;
+        this.email = email;
+        this.displayName = displayName;
+        this.phone = phone;
+        this.address = address;
+        this.website = website;
+        this.twitter = twitter;
+        this.groups = groups;
+        this.language = language;
+        this.locale = locale;
+    }
+
+    public class OcsQuota {
+        public final long free;
+        public final long used;
+        public final long total;
+
+        public OcsQuota(long free, long used, long total) {
+            this.free = free;
+            this.used = used;
+            this.total = total;
+        }
     }
 }

--- a/lib/src/main/java/com/nextcloud/android/sso/ui/UiExceptionManager.java
+++ b/lib/src/main/java/com/nextcloud/android/sso/ui/UiExceptionManager.java
@@ -12,6 +12,7 @@ import android.app.NotificationChannel;
 import android.app.NotificationManager;
 import android.content.Context;
 import android.content.DialogInterface;
+import android.content.Intent;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -21,6 +22,7 @@ import androidx.core.app.NotificationCompat;
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import com.nextcloud.android.sso.R;
 import com.nextcloud.android.sso.exceptions.SSOException;
+import com.nextcloud.android.sso.helper.InternalOption;
 
 public final class UiExceptionManager {
 
@@ -33,7 +35,7 @@ public final class UiExceptionManager {
     public static void showDialogForException(@NonNull Context context,
                                               @NonNull SSOException exception) {
         final int actionText = exception.getPrimaryActionTextRes().orElse(android.R.string.yes);
-        final var optionalAction = exception.getPrimaryAction();
+        final InternalOption<Intent> optionalAction = exception.getPrimaryAction();
 
         if (optionalAction.isPresent()) {
             showDialogForException(context, exception, actionText, (dialog, which) -> context.startActivity(optionalAction.get()));
@@ -49,7 +51,7 @@ public final class UiExceptionManager {
                                               @NonNull SSOException exception,
                                               @StringRes int actionText,
                                               @Nullable DialogInterface.OnClickListener callback) {
-        final var builder = new MaterialAlertDialogBuilder(context)
+        final MaterialAlertDialogBuilder builder = new MaterialAlertDialogBuilder(context)
                 .setMessage(exception.getMessage());
 
         exception.getTitleRes().ifPresent(builder::setTitle);
@@ -68,7 +70,7 @@ public final class UiExceptionManager {
                                                     @NonNull SSOException exception) {
         final String message = exception.getMessage();
 
-        final var builder = new NotificationCompat.Builder(context, "")
+        final NotificationCompat.Builder builder = new NotificationCompat.Builder(context, "")
                 .setSmallIcon(android.R.drawable.ic_dialog_alert)
                 .setTicker(message)
                 //.setDefaults(Notification.DEFAULT_ALL)
@@ -85,11 +87,11 @@ public final class UiExceptionManager {
         //builder.setContentIntent(contentIntent);
 
         // Add as notification
-        final var notificationManager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
+        final NotificationManager notificationManager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
 
         if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O) {
             int importance = NotificationManager.IMPORTANCE_LOW;
-            final var channel = new NotificationChannel(CHANNEL_ID, CHANNEL_ID, importance);
+            final NotificationChannel channel = new NotificationChannel(CHANNEL_ID, CHANNEL_ID, importance);
             //mChannel.enableLights(true);
             notificationManager.createNotificationChannel(channel);
             builder.setChannelId(CHANNEL_ID);

--- a/lib/src/main/java/com/nextcloud/android/sso/ui/UiExceptionManager.java
+++ b/lib/src/main/java/com/nextcloud/android/sso/ui/UiExceptionManager.java
@@ -34,8 +34,8 @@ public final class UiExceptionManager {
 
     public static void showDialogForException(@NonNull Context context,
                                               @NonNull SSOException exception) {
-        final int actionText = exception.getPrimaryActionTextRes().orElse(android.R.string.yes);
-        final InternalOption<Intent> optionalAction = exception.getPrimaryAction();
+        final int actionText = new InternalOption<>(exception.getPrimaryActionTextRes()).orElse(android.R.string.yes);
+        final InternalOption<Intent> optionalAction = new InternalOption<>(exception.getPrimaryAction());
 
         if (optionalAction.isPresent()) {
             showDialogForException(context, exception, actionText, (dialog, which) -> context.startActivity(optionalAction.get()));
@@ -54,7 +54,7 @@ public final class UiExceptionManager {
         final MaterialAlertDialogBuilder builder = new MaterialAlertDialogBuilder(context)
                 .setMessage(exception.getMessage());
 
-        exception.getTitleRes().ifPresent(builder::setTitle);
+        new InternalOption<>(exception.getTitleRes()).ifPresent(builder::setTitle);
 
         if (callback == null) {
             builder.setPositiveButton(R.string.close, null);
@@ -77,7 +77,7 @@ public final class UiExceptionManager {
                 .setAutoCancel(true)
                 .setContentText(message);
 
-        exception.getTitleRes()
+        new InternalOption<>(exception.getTitleRes())
                 .map(context::getString)
                 .ifPresent(builder::setContentTitle);
 

--- a/sample/src/main/java/com/nextcloud/android/sso/sample/MainActivity.java
+++ b/sample/src/main/java/com/nextcloud/android/sso/sample/MainActivity.java
@@ -90,13 +90,13 @@ public class MainActivity extends AppCompatActivity {
 
                     try {
                         /* Perform actual requests */
-                        final var user = ocsAPI.getUser(ssoAccount.userId).execute().body().ocs().data();
+                        final var user = ocsAPI.getUser(ssoAccount.userId).execute().body().ocs.data;
                         final var serverInfo = ocsAPI.getServerInfo().execute().body().ocs.data;
 
                         /* Show result on the UI thread */
                         runOnUiThread(() -> ((TextView) findViewById(R.id.result)).setText(
                                 getString(R.string.account_info,
-                                        user.displayName(),
+                                        user.displayName,
                                         serverInfo.capabilities.theming.name,
                                         serverInfo.version.semanticVersion))
                         );


### PR DESCRIPTION
Desugaring allows to use new Java features and SDK API which are usually embedded in the OS to older device and Java version. This works by embedding these features in the apk.

This library uses it for SDK<24.

A project using this library must enable desugaring, and keep up to date the desugaring library with this project and their AGP. It makes the set up process and maintain process a bit harder.

If I'm correct, it is possible to allow project to enable desugaring if they need SDK>=24 by removing this compile option from the library and let it be done by projects. This sounds like a good idea but this may be counter productive, for instance some project prefer to drop support for older SDK than doing this (I took the first example I've seen, for another project: https://github.com/elastic/apm-agent-android/pull/59).
It would also silently fail for project targeting lower SDK that forget to set this compile option.

This is probably why desugaring is not common in libraries

If we look closer, this has been enable for a small set of features, that are easy to replace:
- var (Java 11), easily replaced by the explicit class
- yield (Java 14), used as a throw
- record (Java 14), easily replaced with `public final` fields and let the IDE write the constructor
- Streams (SDK>=24)
- Optional (SDK>=24)

So, this is a suggestion to get rid of these few features. As a counter side, this leads to a few breaking changes:
- previous record fields aren't access from Java project the same way: from `appType.packageId()` to `appType.packageId`
- lib/src/main/java/com/nextcloud/android/sso/exceptions/SSOException.java functions return nullable type instead of Optional\<T>

So, because of the existence of breaking changes, there are pro/cons to keep or remove desugaring.

[Edit: clarify drawbacks]