### PR TITLE
Do not require desugaring

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ This library allows you to use accounts as well as the network stack provided by
 You can check out the [sample app](https://github.com/nextcloud/Android-SingleSignOn/tree/master/sample) which uses this library to fetch some information via SSO from a Nextcloud instance.
 The sample app uses the [Retrofit approach](#51-using-retrofit). Be aware though, that it is for demonstration purposes only. Exception handling, state management etc. must be implemented depending on your use case.
 
+If you need to support __SDK lower than 24__, you must enable [library desugaring](https://developer.android.com/studio/write/java8-support#library-desugaring).
+
 ### 1) Add this library to your project
 
 ```gradle

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -55,7 +55,6 @@ android {
     }
 
     compileOptions {
-        coreLibraryDesugaringEnabled true
         sourceCompatibility JavaVersion.VERSION_17
         targetCompatibility JavaVersion.VERSION_17
     }
@@ -114,8 +113,6 @@ detekt {
 }
 
 dependencies {
-    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.1.3'
-
     implementation "androidx.appcompat:appcompat:1.7.0"
     implementation 'androidx.annotation:annotation:1.9.1'
     implementation 'androidx.core:core:1.13.1'


### PR DESCRIPTION
Desugaring is used by the library for features available from SDK 24. In other words, desugaring is not needed for applications targeting SDK>=24. This is by the way the minSdk of Nextcloud app since a year [1]

If we remove the compile options from the library gradle, it is possible for applications targetting SDK >= 24 to not care about this property, and for other applications to continue supporting older SDK by applying desugaring by themselves. 

I've added a note to the readme to clarify this requirement.

 [1] https://github.com/nextcloud/android/releases/tag/rc-3.27.0-01