### PR TITLE
HTTP header field names should be case insensitive

### DIFF
--- a/lib/src/main/java/com/nextcloud/android/sso/api/Headers.java
+++ b/lib/src/main/java/com/nextcloud/android/sso/api/Headers.java
@@ -1,0 +1,18 @@
+package com.nextcloud.android.sso.api;
+
+import androidx.annotation.NonNull;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class Headers {
+    private final Map<String, String> headers = new HashMap<>();
+
+    public void put(String key, String value) {
+        headers.put(key.toLowerCase(), value);
+    }
+
+    public String get(String key) {
+        return headers.get(key.toLowerCase());
+    }
+}

--- a/lib/src/main/java/com/nextcloud/android/sso/api/ParsedResponse.java
+++ b/lib/src/main/java/com/nextcloud/android/sso/api/ParsedResponse.java
@@ -11,12 +11,10 @@ package com.nextcloud.android.sso.api;
 import androidx.annotation.Nullable;
 
 import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Map;
 
 public class ParsedResponse<T> {
     private final T response;
-    private final Map<String, String> headers = new HashMap<>();
+    private final Headers headers = new Headers();
 
     public ParsedResponse(T response, @Nullable ArrayList<AidlNetworkRequest.PlainHeader> headers) {
         this.response = response;
@@ -39,7 +37,7 @@ public class ParsedResponse<T> {
         return response;
     }
 
-    public Map<String, String> getHeaders() {
+    public Headers getHeaders() {
         return headers;
     }
 }


### PR DESCRIPTION
See https://www.rfc-editor.org/rfc/rfc2616#section-4.2

In the nextcloud notes android app relying on cased headers lead to the app always downloading every note ever written if a reverse proxy automatically converted all proxied headers to lowercase (cloudflare for example  does this).  See https://github.com/nextcloud/notes-android/issues/2531