### PR TITLE
add: network connectivity error

### DIFF
--- a/lib/src/main/java/com/nextcloud/android/sso/exceptions/NextcloudNetworkException.java
+++ b/lib/src/main/java/com/nextcloud/android/sso/exceptions/NextcloudNetworkException.java
@@ -1,0 +1,20 @@
+/*
+ * Nextcloud Android SingleSignOn Library
+ *
+ * SPDX-FileCopyrightText: 2018-2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+package com.nextcloud.android.sso.exceptions;
+
+import androidx.annotation.Nullable;
+import com.nextcloud.android.sso.R;
+
+public class NextcloudNetworkException extends SSOException {
+    public NextcloudNetworkException(@Nullable Throwable cause) {
+        super("Network connection failed. Please check your internet connection and server URL.",
+            R.string.network_error_title,
+            R.string.retry_action,
+            null,
+            cause);
+    }
+}

--- a/lib/src/main/res/values/strings.xml
+++ b/lib/src/main/res/values/strings.xml
@@ -7,6 +7,9 @@
     -->
     <string name="close">Close</string>
 
+    <string name="network_error_title">Network Error</string>
+    <string name="retry_action">Retry</string>
+
     <string name="unknown_error_title">Unknown error</string>
 
     <string name="no_current_account_selected_exception_title">No account selected</string>


### PR DESCRIPTION
### Issue

Instead of handling `UnknownErrorException`, network-related exceptions can be detected and managed directly on the client side. To achieve that, SSO library should detect and throw correct error.

```
java.lang.RuntimeException: [com.nextcloud.android](http://com.nextcloud.android/).sso.exceptions.UnknownErrorException: Unable to resolve host "[cloud.example.com](http://cloud.example.com/)": No address associated with hostname
at io.reactivex.internal.util.ExceptionHelper.wrapOrThrow([ExceptionHelper.java:46](http://exceptionhelper.java:46/))
at io.reactivex.internal.observers.BlockingMultiObserver.blockingGet([BlockingMultiObserver.java:93](http://blockingmultiobserver.java:93/))
at io.reactivex.Maybe.blockingGet([Maybe.java:2321](http://maybe.java:2321/))
at io.reactivex.Observable.blockingSingle([Observable.java:5381](http://observable.java:5381/))
at it.niedermann.owncloud.notes.persistence.NotesServerSyncTask.pullRemoteChanges([NotesServerSyncTask.java:225](http://notesserversynctask.java:225/))
at [it.niedermann.owncloud.notes.persistence.NotesServerSyncTask.run](http://it.niedermann.owncloud.notes.persistence.notesserversynctask.run/)([NotesServerSyncTask.java:102](http://notesserversynctask.java:102/))
at java.util.concurrent.Executors$RunnableAdapter.call([Executors.java:524](http://executors.java:524/))
at [java.util.concurrent.FutureTask.run](http://java.util.concurrent.futuretask.run/)([FutureTask.java:317](http://futuretask.java:317/))
at java.util.concurrent.ThreadPoolExecutor.runWorker([ThreadPoolExecutor.java:1156](http://threadpoolexecutor.java:1156/))
at java.util.concurrent.ThreadPoolExecutor$Worker.run([ThreadPoolExecutor.java:651](http://threadpoolexecutor.java:651/))
at [java.lang.Thread.run](http://java.lang.thread.run/)([Thread.java:1119](http://thread.java:1119/))
Caused by: [com.nextcloud.android](http://com.nextcloud.android/).sso.exceptions.UnknownErrorException: Unable to resolve host "[cloud.example.com](http://cloud.example.com/)": No address associated with hostname
at [com.nextcloud.android](http://com.nextcloud.android/).sso.api.AidlNetworkRequest.performNetworkRequestV2([AidlNetworkRequest.java:179](http://aidlnetworkrequest.java:179/))
at [com.nextcloud.android](http://com.nextcloud.android/).sso.api.NextcloudAPI.performNetworkRequestV2([NextcloudAPI.java:159](http://nextcloudapi.java:159/))
at [com.nextcloud.android](http://com.nextcloud.android/).sso.api.NextcloudAPI.lambda$performRequestObservableV2$0([NextcloudAPI.java:97](http://nextcloudapi.java:97/))
at [com.nextcloud.android](http://com.nextcloud.android/).sso.api.NextcloudAPI.$r8$lambda$af7W9mq2B0ZrhVJwZd-ibFp8T3Y(Unknown Source:0)
at [com.nextcloud.android](http://com.nextcloud.android/).sso.api.NextcloudAPI$$ExternalSyntheticLambda1.subscribe(D8$$SyntheticClass:0)
at io.reactivex.internal.operators.observable.ObservableFromPublisher.subscribeActual([ObservableFromPublisher.java:31](http://observablefrompublisher.java:31/))
at io.reactivex.Observable.subscribe([Observable.java:12284](http://observable.java:12284/))
at io.reactivex.internal.operators.observable.ObservableSingleMaybe.subscribeActual([ObservableSingleMaybe.java:31](http://observablesinglemaybe.java:31/))
at io.reactivex.Maybe.subscribe([Maybe.java:4290](http://maybe.java:4290/))
at io.reactivex.Maybe.blockingGet([Maybe.java:2320](http://maybe.java:2320/))
```


### Example usage

For example, in the Notes app, rather than displaying an error dialog, we can notify the user via a snackbar. This approach avoids aggressively handling transient errors and prevents unnecessary disruption to the user’s workflow.

<img width="1611" height="1034" alt="Screenshot 2025-08-18 at 13 34 17" src="https://github.com/user-attachments/assets/f4b2fd92-aad0-4a3e-af2f-00a81b2f69e8" />
